### PR TITLE
Check if image tag exists prior to build/publish

### DIFF
--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -26,12 +26,8 @@ aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
 echo "Check if tag has already been published..."
-aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1
-IMAGE_TAG_EXISTS=$(echo $?)
-if [ $IMAGE_TAG_EXISTS -eq 0 ];then
-  echo "Image with tag $IMAGE_TAG already published"
-  exit 0
-fi
+aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 || IMAGE_TAG_EXISTS=$?
+[ $IMAGE_TAG_EXISTS -eq 0 ] && echo "Image with tag $IMAGE_TAG already published" && exit 0
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -25,6 +25,8 @@ echo "Authenticating Docker with ECR"
 aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
+echo "Describe Images"
+aws ecr describe-images --repository-name=$IMAGE_NAME --image-ids=imageTag=$IMAGE_TAG --region $REGION
 echo "Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 set -euo pipefail
 
 APP_NAME=$1
@@ -27,12 +27,12 @@ aws ecr get-login-password --region $REGION \
 echo
 echo "Check if tag has already been published..."
 (aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 && IMAGE_TAG_EXISTS=$?) || IMAGE_TAG_EXISTS=$?
-if [ $IMAGE_TAG_EXISTS -ne 0 ];then
+if [ $IMAGE_TAG_EXISTS -eq 0 ];then
+echo "Image with tag $IMAGE_TAG already published"
+exit 0
+fi
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
-exit 0
-fi
-echo "Image with tag $IMAGE_TAG already published"
 
 

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -26,13 +26,17 @@ aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
 echo "Check if tag has already been published..."
-(aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 && IMAGE_TAG_EXISTS=$?) || IMAGE_TAG_EXISTS=$?
-if [ $IMAGE_TAG_EXISTS -eq 0 ];then
+RESULT=""
+RESULT=$(aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION 2> /dev/null ) || true
+if [ ! -z "$RESULT" ];then
 echo "Image with tag $IMAGE_TAG already published"
 exit 0
 fi
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+
+
+
 
 

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 set -euo pipefail
 
 APP_NAME=$1
@@ -26,9 +26,13 @@ aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
 echo "Check if tag has already been published..."
-aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 || IMAGE_TAG_EXISTS=$?
-[ $IMAGE_TAG_EXISTS -eq 0 ] && echo "Image with tag $IMAGE_TAG already published" && exit 0
+(aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1 && IMAGE_TAG_EXISTS=$?) || IMAGE_TAG_EXISTS=$?
+if [ $IMAGE_TAG_EXISTS -ne 0 ];then
 echo "New tag. Publishing image"
 docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+exit 0
+fi
+echo "Image with tag $IMAGE_TAG already published"
+
 

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -25,14 +25,14 @@ echo "Authenticating Docker with ECR"
 aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
-echo "Verify if tag has already been published"
+echo "Check if tag has already been published..."
 aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1
 IMAGE_TAG_EXISTS=$(echo $?)
 if [ $IMAGE_TAG_EXISTS -eq 0 ];then
   echo "Image with tag $IMAGE_TAG already published"
-else
-  echo "New tag. Publishing image"
-  docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
-  docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+  exit 0
 fi
+echo "New tag. Publishing image"
+docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
 

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -25,8 +25,14 @@ echo "Authenticating Docker with ECR"
 aws ecr get-login-password --region $REGION \
   | docker login --username AWS --password-stdin $IMAGE_REGISTRY
 echo
-echo "Describe Images"
-aws ecr describe-images --repository-name=$IMAGE_NAME --image-ids=imageTag=$IMAGE_TAG --region $REGION
-echo "Publishing image"
-docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
-docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+echo "Verify if tag has already been published"
+aws ecr describe-images --repository-name $IMAGE_NAME --image-ids imageTag=$IMAGE_TAG --region $REGION > /dev/null 2>&1
+IMAGE_TAG_EXISTS=$(echo $?)
+if [ $IMAGE_TAG_EXISTS -eq 0 ];then
+  echo "Image with tag $IMAGE_TAG already published"
+else
+  echo "New tag. Publishing image"
+  docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+  docker push $IMAGE_REPOSITORY_URL:$IMAGE_TAG
+fi
+


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-infra/issues/197

## Changes
Check if the image tag exists in AWS ECR. If so, do not republish

## Context for reviewers
On a Deploy failure, the image tag may get uploaded, resulting in a failure when the re-run tries to create a duplicate tag. This work will check for that tag first.

## Testing
<img width="1238" alt="Screenshot 2023-04-11 at 1 25 16 PM" src="https://user-images.githubusercontent.com/88730205/231241468-0c5eee7f-b240-40b6-ac15-839e8750078e.png">

<img width="774" alt="Screenshot 2023-04-11 at 12 14 40 PM" src="https://user-images.githubusercontent.com/88730205/231225043-09cbe0a4-5a62-4fe0-9ccd-21bd065daf9a.png">
