### PR TITLE
Define healthCheck params to avoid force replace

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -145,6 +145,7 @@ resource "aws_ecs_task_definition" "app" {
 
   # when is this needed?
   # task_role_arn      = aws_iam_role.app_service.arn
+
   container_definitions = jsonencode([
     {
       name                   = var.service_name,
@@ -154,7 +155,14 @@ resource "aws_ecs_task_definition" "app" {
       networkMode            = "awsvpc",
       essential              = true,
       readonlyRootFilesystem = true,
-      healthcheck = {
+
+      # Need to define all parameters in the healthCheck block even if we want
+      # to use AWS's defaults, otherwise the terraform plan will show a diff
+      # that will force a replacement of the task definition
+      healthCheck = {
+        interval = 30,
+        retries  = 3,
+        timeout  = 5,
         command = ["CMD-SHELL",
           "wget --no-verbose --tries=1 --spider http://localhost:${var.container_port}/health || exit 1"
         ]


### PR DESCRIPTION
## Ticket

{LINK TO TICKET}

## Changes
see title

## Context for reviewers
We had some stuff in the service module that would force a replacement of the task definition regardless of whether anything changed. This change fixes that by adding some values in the container definition that AWS was setting default values for.

`terraform plan` in `infra/app/envs/dev` before change (on `main`):
![image](https://github.com/navapbc/platform-test/assets/447859/08d63551-1a40-4052-a398-d39aaebea63f)

After change:
<img width="777" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/85a8f298-d930-4ffb-9484-288e1fc10be5">

Note that this PR is for demonstration since this test repo has an actual environment. The actual change will be made in template-infra.

## Testing
see context section