### PR TITLE
Extract build and publish to separate workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,43 @@
+name: Build and Publish
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        default: ${{ github.ref }}
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
+        default: ${{ github.ref }}
+        type: string
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Build release
+        run: make release-build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # !! Update the role-to-assume with the GitHub actions role ARN
+          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+          aws-region: us-east-1
+
+      - name: Publish release
+        run: make release-publish
+

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
-        default: ${{ github.ref }}
+        required: true
         type: string
   workflow_dispatch:
     inputs:
       ref:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
-        default: ${{ github.ref }}
+        required: true
         type: string
 
 jobs:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           # !! Update the role-to-assume with the GitHub actions role ARN
-          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/<PROJECT_NAME>-github-actions
+          role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
           aws-region: us-east-1
 
       - name: Publish release

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          # !! Update the role-to-assume with the GitHub actions role ARN
           role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
           aws-region: us-east-1
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,14 +1,13 @@
 name: Deploy
 
 on:
-  # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
-  # push:
-  #   branches: 
-  #     - 'main'
-  #   paths:
-  #     - 'app/**'
-  #     - 'bin/**'
-  #     - 'infra/**'
+  push:
+    branches: 
+      - 'main'
+    paths:
+      - 'app/**'
+      - 'bin/**'
+      - 'infra/**'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,8 @@ concurrency: cd-${{ inputs.environment || 'dev' }}
 jobs:
   build-and-publish:
     uses: ./.github/workflows/build-and-publish.yml
+    with:
+      ref: ${{ github.ref }}
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,5 +36,10 @@ jobs:
     needs: [build-and-publish]
     steps:
       - uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
+          aws-region: us-east-1
       - name: Deploy release
         run: make release-deploy ENVIRONMENT="$ENVIRONMENT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,13 +1,14 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'app/**'
-      - 'bin/**'
-      - 'infra/**'
+  # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
+  # push:
+  #   branches: 
+  #     - 'main'
+  #   paths:
+  #     - 'app/**'
+  #     - 'bin/**'
+  #     - 'infra/**'
   workflow_dispatch:
     inputs:
       environment:
@@ -27,27 +28,10 @@ env:
 concurrency: cd-${{ inputs.environment || 'dev' }}
 
 jobs:
+  build-and-publish:
+    uses: ./.github/workflows/build-and-publish.yml
   deploy:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      id-token: write
-
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Build release
-        run: make release-build
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: arn:aws:iam::430004246987:role/platform-test-github-actions
-          aws-region: us-east-1
-
-      - name: Publish release
-        run: make release-publish
-
       - name: Deploy release
         run: make release-deploy ENVIRONMENT="$ENVIRONMENT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,7 @@ jobs:
       ref: ${{ github.ref }}
   deploy:
     runs-on: ubuntu-latest
+    needs: [build-and-publish]
     steps:
       - uses: actions/checkout@v3
       - name: Deploy release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: 
+    branches:
       - 'main'
     paths:
       - 'app/**'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,5 +34,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Deploy release
         run: make release-deploy ENVIRONMENT="$ENVIRONMENT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ concurrency: cd-${{ inputs.environment || 'dev' }}
 
 jobs:
   build-and-publish:
+    name: Build
     uses: ./.github/workflows/build-and-publish.yml
     with:
       ref: ${{ github.ref }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,6 +34,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build-and-publish]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       ref: ${{ github.ref }}
   deploy:
+    name: Deploy
     runs-on: ubuntu-latest
     needs: [build-and-publish]
     permissions:


### PR DESCRIPTION
## Ticket

N/A

## Changes
* Pull build-and-publish steps from cd.yml into separate workflow
* Call build-and-publish from cd.yml

## Context
I'm working on recording a demo of template infra, but building the example docker image takes too long on M1 macs (~10 minutes to build template-application-nextjs).

This change will us to use github actions to do the docker build and publish step, which will speed up the demo, and can be useful for others as well to run builds without needing to use local machine.

## Testing
1. Ran build-and-publish directly:
<img width="1257" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/5453f8c3-8cb5-4a71-9c3a-a5c9c4cebefc">

Successful run: https://github.com/navapbc/platform-test/actions/runs/5157171673

2. Ran cd.yml 
<img width="941" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/05f1859b-f87c-4b50-a87b-3acb57cf352d">

Successful run: https://github.com/navapbc/platform-test/actions/runs/5157143380/jobs/9289142155

