### PR TITLE
Don't create migrator role if has_db is false

### DIFF
--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -13,6 +13,8 @@ resource "aws_iam_role" "app_service" {
 }
 
 resource "aws_iam_role" "migrator_task" {
+  count = var.db_vars != null ? 1 : 0
+
   name               = "${var.service_name}-migrator"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
 }

--- a/infra/modules/service/database-access.tf
+++ b/infra/modules/service/database-access.tf
@@ -24,7 +24,7 @@ resource "aws_iam_role_policy_attachment" "app_service_db_access" {
 resource "aws_iam_role_policy_attachment" "migrator_db_access" {
   count = var.db_vars != null ? 1 : 0
 
-  role       = aws_iam_role.migrator_task.name
+  role       = aws_iam_role.migrator_task[0].name
   policy_arn = var.db_vars.migrator_access_policy_arn
 }
 

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -22,5 +22,5 @@ output "application_log_stream_prefix" {
 
 output "migrator_role_arn" {
   description = "ARN for role to use for migration"
-  value       = aws_iam_role.migrator_task.arn
+  value       = length(aws_iam_role.migrator_task) > 0 ? aws_iam_role.migrator_task[0].arn : null
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

The migrator task role isn't needed for projects that don't have a database

## Testing

Terraform plan shows no infra change as expected

<img width="642" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/3fa5c535-3628-4810-8155-27a73c1b6dfe">
