### PR TITLE
Group logs in infra CI service tests

### DIFF
--- a/.github/workflows/ci-infra-service.yml
+++ b/.github/workflows/ci-infra-service.yml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - infra/*/service/**
-      - test/**
+      - infra/test/**
       - .github/workflows/ci-infra-service.yml
   pull_request:
     paths:
       - infra/*/service/**
-      - test/**
+      - infra/test/**
       - .github/workflows/ci-infra-service.yml
   workflow_dispatch:
 

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -36,7 +36,7 @@ func TestService(t *testing.T) {
 	TerraformInit(t, terraformOptions, "dev.s3.tfbackend")
 	fmt.Println("::endgroup::")
 
-	defer terraform.WorkspaceDelete(t, terraformOptions, workspaceName)
+	defer DeleteWorkspace(t, terraformOptions, workspaceName)
 	fmt.Println("::group::Select new terraform workspace")
 	terraform.WorkspaceSelectOrNew(t, terraformOptions, workspaceName)
 	fmt.Println("::endgroup::")
@@ -130,5 +130,11 @@ func DestroyService(t *testing.T, terraformOptions *terraform.Options) {
 	EnableDestroyService(t, terraformOptions)
 	fmt.Println("::group::Destroy service layer")
 	terraform.Destroy(t, terraformOptions)
+	fmt.Println("::endgroup::")
+}
+
+func DeleteWorkspace(t *testing.T, terraformOptions *terraform.Options, workspaceName string) {
+	fmt.Println("::group::Delete test workspace")
+	terraform.WorkspaceDelete(t, terraformOptions, workspaceName)
 	fmt.Println("::endgroup::")
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

About half of the logs were grouped for infra CI service tests, and the other half weren't grouped, making the logs still hard to read. This change groups the rest of the logs.

## Testing

Example of CI run before grouping: https://github.com/navapbc/platform-test/actions/runs/6102790192/job/16561993591

Example from this PR of CI run after grouping: https://github.com/navapbc/platform-test/actions/runs/6103449076/job/16563864474

<img width="729" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/399fe07f-61b4-402b-abce-956f9f608e20">
