### PR TITLE
Remove conflicting empty managed policy block

### DIFF
--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -17,10 +17,6 @@ resource "aws_iam_role" "migrator_task" {
 
   name               = "${var.service_name}-migrator"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume_role_policy.json
-
-  managed_policy_arns = [
-
-  ]
 }
 
 data "aws_iam_policy_document" "ecs_tasks_assume_role_policy" {

--- a/infra/modules/service/database-access.tf
+++ b/infra/modules/service/database-access.tf
@@ -21,6 +21,13 @@ resource "aws_iam_role_policy_attachment" "app_service_db_access" {
   policy_arn = var.db_vars.app_access_policy_arn
 }
 
+resource "aws_iam_role_policy_attachment" "migrator_db_access" {
+  count = var.db_vars != null ? 1 : 0
+
+  role       = aws_iam_role.migrator_task[0].name
+  policy_arn = var.db_vars.migrator_access_policy_arn
+}
+
 # TODO: Delete as part 3 of multipart update https://github.com/navapbc/template-infra/issues/354#issuecomment-1693973424
 resource "aws_iam_role_policy_attachment" "temp_app_migrator_db_access" {
   count = var.db_vars != null ? 1 : 0

--- a/infra/modules/service/database-access.tf
+++ b/infra/modules/service/database-access.tf
@@ -21,13 +21,6 @@ resource "aws_iam_role_policy_attachment" "app_service_db_access" {
   policy_arn = var.db_vars.app_access_policy_arn
 }
 
-resource "aws_iam_role_policy_attachment" "migrator_db_access" {
-  count = var.db_vars != null ? 1 : 0
-
-  role       = aws_iam_role.migrator_task[0].name
-  policy_arn = var.db_vars.migrator_access_policy_arn
-}
-
 # TODO: Delete as part 3 of multipart update https://github.com/navapbc/template-infra/issues/354#issuecomment-1693973424
 resource "aws_iam_role_policy_attachment" "temp_app_migrator_db_access" {
   count = var.db_vars != null ? 1 : 0


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

There was resource cycling on main branch due to the conflict between [the inline managed_policy_arns block](https://github.com/navapbc/template-infra/blob/057c763b1a24f076f2c57775cb73eaa02d052be5/infra/modules/service/access-control.tf#L21-L23) and the [policy attachment](https://github.com/navapbc/template-infra/blob/057c763b1a24f076f2c57775cb73eaa02d052be5/infra/modules/service/database-access.tf#L24-L29). This PR removes the inline block which was conflicting.

## Testing

Previously, running `make infra-update-app-service APP_NAME=app ENVIRONMENT=dev` over and over again would cycle between the following plans.
![image](https://github.com/navapbc/platform-test/assets/447859/7409115a-85d9-4676-b36d-546ef78f2d4c)
![image](https://github.com/navapbc/platform-test/assets/447859/a7d428d6-f3db-4c05-b3fb-c88742b04144)

After this change, the terraform plan is clean
<img width="388" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/e5ff7550-445d-4ff4-813a-71e2f75ba458">

