### PR TITLE
Use make command in run db migrations

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -44,8 +44,6 @@ DB_MIGRATOR_USER=$(terraform -chdir="infra/$APP_NAME/app-config" output -json en
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
-MODULE_DIR="infra/$APP_NAME/service"
-CONFIG_NAME="$ENVIRONMENT"
 TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_task_definition.app -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
 
 echo "::endgroup::"

--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -46,7 +46,7 @@ echo "::group::Step 1. Update task definition without updating service"
 
 MODULE_DIR="infra/$APP_NAME/service"
 CONFIG_NAME="$ENVIRONMENT"
-TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_task_definition.app -var=image_tag=$IMAGE_TAG" ./bin/terraform-init-and-apply.sh "$MODULE_DIR" "$CONFIG_NAME"
+TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_task_definition.app -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
 
 echo "::endgroup::"
 echo


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

When merging [#42](https://github.com/navapbc/template-infra/pull/433) there was one place that was doing a terraform apply on the infra/app/service layer that I didn't update, which resulted in a failure when running db migrations (see failed run: https://github.com/navapbc/platform-test/actions/runs/6118143457/job/16605796551)

Failed with this error
```
 │ Error: No value for required variable
  │ 
  │   on variables.tf line 1:
  │    1: variable "environment_name" {
  │ 
  │ The root module input variable "environment_name" is not set, and has no
  │ default value. Use a -var or -var-file command line argument to provide a
  │ value for this variable.
  ╵
```

This change fixes that by having the run-database-migrations.sh script call the `make infra-update-app-service` target rather than calling terraform-init-and-apply directly.

## Testing

Before this change I ran `make release-run-database-migrations APP_NAME=app ENVIRONMENT=dev` and I was able to reproduce the error:

<img width="739" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/67b917a1-95a2-4c1c-bf0f-8cb9cdfa5061">

After the fix I re-ran the command and it succeeded:

<img width="680" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/c8103d92-600c-4f54-8342-d4d3b66a3de2">
