### PR TITLE
Fix: add -reconfigure to tf init call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ infra-update-app-build-repository: ## Create or update $APP_NAME's build reposit
 infra-update-app-database: ## Create or update $APP_NAME's database module for $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
-	terraform -chdir="infra/$(APP_NAME)/database" init -backend-config="$(ENVIRONMENT).s3.tfbackend"
+	terraform -chdir="infra/$(APP_NAME)/database" init -input=false -reconfigure -backend-config="$(ENVIRONMENT).s3.tfbackend"
 	terraform -chdir="infra/$(APP_NAME)/database" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-update-app-database-roles: ## Create or update database roles and schemas for $APP_NAME's database in $ENVIRONMENT
@@ -112,7 +112,7 @@ infra-update-app-service: ## Create or update $APP_NAME's web service module
 	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
-	terraform -chdir="infra/$(APP_NAME)/service" init -backend-config="$(ENVIRONMENT).s3.tfbackend"
+	terraform -chdir="infra/$(APP_NAME)/service" init -input=false -reconfigure -backend-config="$(ENVIRONMENT).s3.tfbackend"
 	terraform -chdir="infra/$(APP_NAME)/service" apply -var="environment_name=$(ENVIRONMENT)"
 
 # The prerequisite for this rule is obtained by


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

In https://github.com/navapbc/template-infra/pull/433 we switched the make infra-update-app-database and make infra-update-app-service commands to use terraform init directly rather than the terraform-init-and-apply.sh script. During that transition we didn't port over the -reconfigure option which is needed when switching around between different backend configurations (e.g. between different environments). This change fixes that.

## Testing

Ran both commands and saw that they still work and show no terraform plan changes.

update-app-service command:
<img width="741" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/548e9268-7778-4d7d-beab-aa50b21cef78">

update-app-database command:
<img width="751" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/94e866e4-938a-4e3c-8027-d62576a1d57c">

