### PR TITLE
Fix run-database-migrations

### DIFF
--- a/bin/run-database-migrations.sh
+++ b/bin/run-database-migrations.sh
@@ -58,4 +58,4 @@ ENVIRONMENT_VARIABLES=$(cat << EOF
 EOF
 )
 
-./bin/run-command.sh "$APP_NAME" "$ENVIRONMENT" "$COMMAND" "$ENVIRONMENT_VARIABLES"
+./bin/run-command.sh --environment-variables "$ENVIRONMENT_VARIABLES" "$APP_NAME" "$ENVIRONMENT" "$COMMAND"


### PR DESCRIPTION
## Ticket

Work for https://github.com/navapbc/template-infra/pull/440

## Changes

see title

## Context for reviewers

In https://github.com/navapbc/template-infra/pull/440 we added an option to override task role but also changed the way the run-command script accepts environment variables, which broke migrations. This change fixes that.

## Testing

Before the fix, I ran `make release-run-database-migrations APP_NAME=app ENVIRONMENT=dev` and was able to reproduce the issue. See that environment variables don't get set:

<img width="477" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/7711a7c9-397b-42ee-8338-62598d1f5b97">

After the fix, I re-ran and the migrations were successful

<img width="647" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/171087e0-f9e3-4291-abe8-45868d502d1c">
