### PR TITLE
Add concurrency restriction to build and publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,6 +26,7 @@ jobs:
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
+    concurrency: ${{ github.action }}-${{ inputs.ref }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Uses  for concurrency

## Ticket

Resolves [#427](https://github.com/navapbc/template-infra/issues/427)

## Changes

- Add `concurrency` key to stop race condition for multiple runs on same branch
- Uses github action and commit hash
  + Action because only concurrent runs of same action is an issue
  + commit hash because that's the image tag and causes conflict

## Context for reviewers

No additional context

## Testing

- [ ] Does it run normally with expected results?
- [ ] Does it avoid concurrency failures?