### PR TITLE
Install role manager dependencies on every apply

### DIFF
--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -51,7 +51,7 @@ resource "aws_lambda_function" "role_manager" {
 # Installs python packages needed by the role manager lambda function before
 # creating the zip archive. Reinstalls whenever requirements.txt changes
 resource "terraform_data" "role_manager_python_vendor_packages" {
-  triggers_replace = file("${path.module}/role_manager/requirements.txt")
+  triggers_replace = fileset(path.module, "role_manager/vendor/**")
 
   provisioner "local-exec" {
     command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor"

--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -51,8 +51,7 @@ resource "aws_lambda_function" "role_manager" {
 # Installs python packages needed by the role manager lambda function before
 # creating the zip archive. Reinstalls whenever requirements.txt changes
 resource "terraform_data" "role_manager_python_vendor_packages" {
-  triggers_replace = fileset(path.module, "role_manager/vendor/**")
-
+  triggers_replace = timestamp()
   provisioner "local-exec" {
     command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor"
   }


### PR DESCRIPTION
#446

## Ticket

Resolves [#446](https://github.com/navapbc/template-infra/issues/446)

## Changes

Recursively checks for changes in vendor dir using:
`fileset(path.module, "role_manager/vendor/**")`

## Context for reviewers

Meant to prevent issue of package dependencies being missed on second engineers deployed.

## Testing

- [x] Run new fileset on reset role_manager directory confirm package installation
- [ ] Run again. Confirm no unnecessary installation
- [x] Reset directory. Run again. Confirm installation