### PR TITLE
Associate parameter group with rds cluster

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -48,6 +48,8 @@ resource "aws_rds_cluster" "db" {
   vpc_security_group_ids = [aws_security_group.db.id]
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
 }
 
 resource "aws_rds_cluster_instance" "primary" {

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -66,6 +66,7 @@ resource "aws_rds_cluster_instance" "primary" {
   auto_minor_version_upgrade = true
   monitoring_role_arn        = aws_iam_role.rds_enhanced_monitoring.arn
   monitoring_interval        = 30
+  db_parameter_group_name    = aws_db_parameter_group.rds_query_logging.name
 }
 
 resource "random_password" "random_db_password" {
@@ -89,6 +90,24 @@ resource "aws_kms_key" "db" {
 # -------------
 
 resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
+  name        = var.name
+  family      = data.aws_rds_engine_version.db_version.parameter_group_family
+  description = "Default cluster parameter group"
+
+  parameter {
+    name = "log_statement"
+    # Logs data definition statements (e.g. DROP, ALTER, CREATE)
+    value = "ddl"
+  }
+
+  parameter {
+    name = "log_min_duration_statement"
+    # Logs all statements that run 100ms or longer
+    value = "100"
+  }
+}
+
+resource "aws_db_parameter_group" "rds_query_logging" {
   name        = var.name
   family      = data.aws_rds_engine_version.db_version.parameter_group_family
   description = "Default cluster parameter group"

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -1,6 +1,11 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+data "aws_rds_engine_version" "db_version" {
+  engine       = "aurora-postgresql"
+  default_only = true
+}
+
 locals {
   master_username       = "postgres"
   primary_instance_name = "${var.name}-primary"
@@ -23,7 +28,7 @@ resource "aws_rds_cluster" "db" {
   # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html
   cluster_identifier = var.name
 
-  engine            = "aurora-postgresql"
+  engine            = data.aws_rds_engine_version.db_version.engine
   engine_mode       = "provisioned"
   database_name     = var.database_name
   port              = var.port
@@ -85,7 +90,7 @@ resource "aws_kms_key" "db" {
 
 resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
   name        = var.name
-  family      = "aurora-postgresql13"
+  family      = data.aws_rds_engine_version.db_version.parameter_group_family
   description = "Default cluster parameter group"
 
   parameter {

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -55,6 +55,9 @@ resource "aws_rds_cluster" "db" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
 
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
+  depends_on = [
+    aws_cloudwatch_log_group.postgres
+  ]
 }
 
 resource "aws_rds_cluster_instance" "primary" {
@@ -88,6 +91,11 @@ resource "aws_kms_key" "db" {
 
 # Query Logging
 # -------------
+
+resource "aws_cloudwatch_log_group" "postgres" {
+  name              = "/aws/rds/instance/${local.primary_instance_name}"
+  retention_in_days = 7 # TODO update this based on platform decision
+}
 
 resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
   name        = var.name

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -52,7 +52,13 @@ resource "aws_rds_cluster" "db" {
 
   vpc_security_group_ids = [aws_security_group.db.id]
 
-  enabled_cloudwatch_logs_exports = ["postgresql"]
+  enabled_cloudwatch_logs_exports = [
+    "postgresql",
+    # "audit", 
+    # "error", 
+    # "general", 
+    # "slowquery"
+  ]
 
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
   depends_on = [
@@ -105,13 +111,15 @@ resource "aws_rds_cluster_parameter_group" "rds_query_logging" {
   parameter {
     name = "log_statement"
     # Logs data definition statements (e.g. DROP, ALTER, CREATE)
-    value = "ddl"
+    value = "all"
   }
 
   parameter {
     name = "log_min_duration_statement"
     # Logs all statements that run 100ms or longer
-    value = "100"
+    # value = "100"
+    # Log all statements
+    value = "1"
   }
 }
 
@@ -123,12 +131,14 @@ resource "aws_db_parameter_group" "rds_query_logging" {
   parameter {
     name = "log_statement"
     # Logs data definition statements (e.g. DROP, ALTER, CREATE)
-    value = "ddl"
+    value = "all"
   }
 
   parameter {
     name = "log_min_duration_statement"
     # Logs all statements that run 100ms or longer
-    value = "100"
+
+    # value = "100"
+    value = "1"
   }
 }

--- a/infra/modules/database/role_manager/role_manager.py
+++ b/infra/modules/database/role_manager/role_manager.py
@@ -3,6 +3,7 @@ import itertools
 from operator import itemgetter
 import os
 import logging
+import json
 from pg8000.native import Connection, identifier
 
 logger = logging.getLogger()


### PR DESCRIPTION
## Ticket

Resolves [#385](https://github.com/navapbc/template-infra/issues/385)

## Changes

- Associate parameter group with db in db module
- Use data module to avoid circular dependency

## Testing

Terraform creates expected changes without deletion of resources (excluding automatic replacement of lambda package)
<img width="1023" alt="Screenshot 2023-09-19 at 10 45 47 AM" src="https://github.com/navapbc/platform-test/assets/127765344/ac7990a0-be91-4fe0-947b-a34ea93e6a8d">
After application, expected parameter group is applied to cluster
<img width="542" alt="Screenshot 2023-09-19 at 10 45 35 AM" src="https://github.com/navapbc/platform-test/assets/127765344/5c1592e2-4ddf-452a-a253-e80b6a6abcc4">
