### PR TITLE
Enable db query logging

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -31,6 +31,8 @@ resource "aws_rds_cluster" "db" {
   storage_encrypted           = true
   kms_key_id                  = aws_kms_key.db.arn
 
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
+
   # checkov:skip=CKV_AWS_128:Auth decision needs to be ironed out
   # checkov:skip=CKV_AWS_162:Auth decision needs to be ironed out
   iam_database_authentication_enabled = true


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/385

## Changes

* Attach cluster parameter group to db cluster

## Context for reviewers

We [created a cluster parameter group in the database module](https://github.com/navapbc/template-infra/blob/5dedfb0a4618a6302741ab25ed8be0d872cc075c/infra/modules/database/main.tf#L71-L87) but never attached it to the db cluster resource, so the db cluster didn't pick up the parameters. This means that query logging was never enabled. This change attaches the parameter group to the cluster which enables query logging.

## Testing

I attached the parameter group to the cluster, rebooted the instance, and ran `make infra-update-app-database-roles APP_NAME=app ENVIRONMENT=dev` and `make infra-check-app-database-roles APP_NAME=app ENVIRONMENT=dev` both of which invoke DDL commands which should be logged. Here are screenshots of those logs in AWS console:

Logs from `make infra-update-app-database-roles APP_NAME=app ENVIRONMENT=dev`
<img width="1584" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/f673e4a5-f9de-4252-b6ff-f50b5e83500a">

Logs from `make infra-check-app-database-roles APP_NAME=app ENVIRONMENT=dev`
<img width="1556" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/dcbb76bf-7655-4983-ba72-22801193e37a">
