### PR TITLE
Add service config options to env-config

### DIFF
--- a/docs/infra/set-up-app-env.md
+++ b/docs/infra/set-up-app-env.md
@@ -10,6 +10,7 @@ Before setting up the application's environments you'll need to have:
 
 1. [A compatible application in the app folder](https://github.com/navapbc/template-infra/blob/main/template-only-docs/application-requirements.md)
 2. [Configure the app](/infra/app/app-config/main.tf). Make sure you update `has_database` to `true` or `false` depending on whether or not your application has a database to integrate with.
+   1. If you're configuring your production environment, make sure to update the `service_cpu`, `service_memory`, and `service_desired_instance_count` settings based on the project's needs. If your application is sensitive to performance, consider doing a load test.
 3. [Create a nondefault VPC to be used by the application](./set-up-network.md)
 4. (If the application has a database) [Set up the database for the application](./set-up-database.md)
 5. (If you have an incident management service) [Set up monitoring](./set-up-monitoring-alerts.md)

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -17,7 +17,10 @@ output "network_name" {
 
 output "service_config" {
   value = {
-    region = var.default_region
+    region                 = var.default_region
+    cpu                    = var.service_cpu
+    memory                 = var.service_memory
+    desired_instance_count = var.service_desired_instance_count
   }
 }
 

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -24,3 +24,18 @@ variable "has_database" {
 variable "has_incident_management_service" {
   type = bool
 }
+
+variable "service_cpu" {
+  type    = number
+  default = 256
+}
+
+variable "service_memory" {
+  type    = number
+  default = 512
+}
+
+variable "service_desired_instance_count" {
+  type    = number
+  default = 1
+}

--- a/infra/app/app-config/prod.tf
+++ b/infra/app/app-config/prod.tf
@@ -6,4 +6,11 @@ module "prod_config" {
   network_name                    = "prod"
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
+
+  # These numbers are a starting point based on this article
+  # Update the desired instance size and counts based on the project's specific needs
+  # https://conchchow.medium.com/aws-ecs-fargate-compute-capacity-planning-a5025cb40bd0
+  service_cpu                    = 1024
+  service_memory                 = 4096
+  service_desired_instance_count = 3
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -114,6 +114,10 @@ module "service" {
   public_subnet_ids     = data.aws_subnets.public.ids
   private_subnet_ids    = data.aws_subnets.private.ids
 
+  cpu                    = local.service_config.cpu
+  memory                 = local.service_config.memory
+  desired_instance_count = local.service_config.desired_instance_count
+
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 
   db_vars = module.app_config.has_database ? {


### PR DESCRIPTION
## Ticket

N/A

## Changes

* Add env-config settings for service CPU, memory, and desired instance count
* Set prod to 1 vCPU, 4 GB memory, and 3 instances
* Add instructions

## Context

Add env-config settings for setting an environment's service's CPU, memory, and desired instance count. This allows a project to have separate settings for each environment.

## Testing

Temporarily set app-config's has_database to false (so we don't need to create a prod database layer), and set prod.tf's config to set network_name to `"dev"` (so we don't need to create a prod VPC), then ran terraform plan for prod. Here are the relevant sections that show that desired count is 3 and that CPU and memory settings are different from the defaults:

Ran the following commands (image_tag is the current commit on `main` branch)
```
make infra-configure-app-service APP_NAME=app ENVIRONMENT=prod
TF_CLI_ARGS_apply='-var=image_tag="0b7fbe62bb7a925ffd314dae444ab3a84b968701"' make infra-update-app-service APP_NAME=app ENVIRONMENT=prod
```
Terraform plan screenshots:

<img width="628" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/47be312b-1a98-4b30-a2ab-5c63c2ae1462">

<img width="468" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/2cd7cc95-a66c-4b51-bd91-99ad9efb61fe">


