### PR TITLE
Test feature flag endpoint

### DIFF
--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -99,6 +99,11 @@ func RunEndToEndTests(t *testing.T, terraformOptions *terraform.Options) {
 	http_helper.HttpGetWithRetryWithCustomValidation(t, serviceEndpoint, nil, 5, 1*time.Second, func(responseStatus int, responseBody string) bool {
 		return responseStatus == 200
 	})
+	// Hit feature flags endpoint to make sure Evidently integration is working
+	featureFlagsEndpoint := fmt.Sprintf("%s/feature-flags", serviceEndpoint)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, featureFlagsEndpoint, nil, 5, 1*time.Second, func(responseStatus int, responseBody string) bool {
+		return responseStatus == 200
+	})
 	fmt.Println("::endgroup::")
 }
 


### PR DESCRIPTION
## Ticket

N/A

## Changes

* Hit feature-flags endpoint in example app during CI Infra tests

## Context

[This commit](https://github.com/navapbc/template-infra/commit/8bfab4387277bb7789d1aebc062bb3f6ba9a1e1d) broke the feature flag evidently integration (fixed now) but it was not caught as part of any automated testing. This change adds a ping to the feature-flags endpoint which integrates with Evidently to catch future regressions.

## Testing

Since this is just a change to CI, just leveraging CI for this