### PR TITLE
Remove workaround for VPC endpoint availability

### DIFF
--- a/infra/modules/network/vpc-endpoints.tf
+++ b/infra/modules/network/vpc-endpoints.tf
@@ -10,9 +10,8 @@ locals {
     # AWS services used by ECS Fargate: ECR to fetch images, S3 for image layers, and CloudWatch for logs
     ["ecr.api", "ecr.dkr", "s3", "logs"],
 
-    # Workaround: Feature flags use AWS Evidently, but we are going to create that VPC endpoint separately
-    # rather than as part of this list in order to get around the limitation that AWS Evidently
-    # is not available in some availability zones (at the time of writing)
+    # Feature flags with AWS Evidently
+    ["evidently", "evidently-dataplane"],
 
     # AWS services used by the database's role manager
     var.has_database ? ["ssm", "kms", "secretsmanager"] : [],
@@ -37,6 +36,35 @@ data "aws_region" "current" {}
 # See https://repost.aws/knowledge-center/lambda-vpc-parameter-store
 # See https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html#create-interface-endpoint
 
+data "aws_subnet" "private" {
+  count = length(module.aws_vpc.private_subnets)
+  id    = module.aws_vpc.private_subnets[count.index]
+}
+
+# AWS services may only be available in certain regions and availability zones,
+# so we use this data source to get that information and only create
+# VPC endpoints in the regions / availability zones where the particular service
+# is available.
+data "aws_vpc_endpoint_service" "aws_service" {
+  for_each = local.interface_vpc_endpoints
+  service  = each.key
+}
+
+locals {
+  # Map from the name of an AWS service to a list of the private subnets that are in availability
+  # zones where the service is available. Only create this map for AWS services where we are going
+  # to create an Interface VPC endpoint, which require a list of subnet ids in which to create the
+  # elastic network interface for the endpoint.
+  aws_service_subnets = {
+    for service in local.interface_vpc_endpoints :
+    service => [
+      for subnet in data.aws_subnet.private[*] :
+      subnet.id
+      if contains(data.aws_vpc_endpoint_service.aws_service[service].availability_zones, subnet.availability_zone)
+    ]
+  }
+}
+
 resource "aws_security_group" "aws_services" {
   name_prefix = var.aws_services_security_group_name_prefix
   description = "VPC endpoints to access AWS services from the VPCs private subnets"
@@ -50,7 +78,7 @@ resource "aws_vpc_endpoint" "interface" {
   service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.aws_services.id]
-  subnet_ids          = module.aws_vpc.private_subnets
+  subnet_ids          = local.aws_service_subnets[each.key]
   private_dns_enabled = true
 }
 
@@ -70,66 +98,3 @@ resource "aws_vpc_endpoint" "gateway" {
 # because at the time of writing, Evidently isn't supported in certain availability zones.
 # So we filter down the list of private subnets by the ones in the availability zones that are
 # supported by Evidently before creating the VPC endpoint.
-
-data "aws_subnet" "private" {
-  count = length(module.aws_vpc.private_subnets)
-  id    = module.aws_vpc.private_subnets[count.index]
-}
-
-locals {
-  # At the time of writing, these are the only availability zones supported by AWS CloudWatch Evidently
-  # This list was obtained by using the AWS Console, going through each US region, attempting to add
-  # a VPC endpoint for Evidently in the default VPC, and seeing which availability zones show up as
-  # options.
-  evidently_az_ids = [
-    "use1-az2",
-    "use1-az4",
-    "use1-az6",
-    "use2-az1",
-    "use2-az2",
-    "use2-az3",
-    "usw2-az1",
-    "usw2-az2",
-    "usw2-az3",
-  ]
-
-  evidently_dataplane_az_ids = [
-    "use1-az1",
-    "use1-az4",
-    "use1-az6",
-    "use2-az1",
-    "use2-az2",
-    "use2-az3",
-    "usw2-az1",
-    "usw2-az2",
-    "usw2-az3",
-  ]
-
-  aws_evidently_subnet_ids = [
-    for subnet in data.aws_subnet.private[*] : subnet.id
-    if contains(local.evidently_az_ids, subnet.availability_zone_id)
-  ]
-
-  aws_evidently_dataplane_subnet_ids = [
-    for subnet in data.aws_subnet.private[*] : subnet.id
-    if contains(local.evidently_dataplane_az_ids, subnet.availability_zone_id)
-  ]
-}
-
-resource "aws_vpc_endpoint" "evidently" {
-  vpc_id              = module.aws_vpc.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.evidently"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.aws_services.id]
-  subnet_ids          = local.aws_evidently_subnet_ids
-  private_dns_enabled = true
-}
-
-resource "aws_vpc_endpoint" "evidently_dataplane" {
-  vpc_id              = module.aws_vpc.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.evidently-dataplane"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.aws_services.id]
-  subnet_ids          = local.aws_evidently_dataplane_subnet_ids
-  private_dns_enabled = true
-}

--- a/infra/modules/network/vpc-endpoints.tf
+++ b/infra/modules/network/vpc-endpoints.tf
@@ -90,11 +90,3 @@ resource "aws_vpc_endpoint" "gateway" {
   vpc_endpoint_type = "Gateway"
   route_table_ids   = module.aws_vpc.private_route_table_ids
 }
-
-# Interface VPC Endpoint for AWS CloudWatch Evidently (Workaround)
-# ----------------------------------------------------------------
-#
-# Add Interface VPC Endpoint for AWS CloudWatch Evidently separately from other VPC Endpoints,
-# because at the time of writing, Evidently isn't supported in certain availability zones.
-# So we filter down the list of private subnets by the ones in the availability zones that are
-# supported by Evidently before creating the VPC endpoint.


### PR DESCRIPTION
## Ticket

n/a

## Changes

* Replace hardcoded list of Evidently AZs with aws_vpc_endpoint_service data source

## Context

@jamesbursa showed that the information about an AWS service's region/az availability can be fetched from the data source aws_vpc_endpoint_service rather than hardcoded. This change removes the hardcoding of the region/AZs for the Evidently service and uses this data source instead. An additional benefit is that this approach will make the VPC endpoint resource configuration for other existing and future services more robust.

## Testing

First moved the existing vpc endpoints to the new terraform configuration address:
<img width="1044" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/d6a1669e-da98-4770-ab56-84387f289489">

Then run terraform plan to show a clean plan
<img width="431" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/6e0c7cde-59b5-482d-9709-6939123682a8">
