### PR TITLE
Remove unused config value

### DIFF
--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -2,7 +2,6 @@ output "database_config" {
   value = var.has_database ? {
     region                      = var.default_region
     cluster_name                = "${var.app_name}-${var.environment}"
-    access_policy_name          = "${var.app_name}-${var.environment}-db-access"
     app_username                = "app"
     migrator_username           = "migrator"
     schema_name                 = var.app_name

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -76,7 +76,6 @@ module "database" {
   source = "../../modules/database"
 
   name                        = "${local.prefix}${local.database_config.cluster_name}"
-  access_policy_name          = "${local.prefix}${local.database_config.access_policy_name}"
   app_access_policy_name      = "${local.prefix}${local.database_config.app_access_policy_name}"
   migrator_access_policy_name = "${local.prefix}${local.database_config.migrator_access_policy_name}"
 

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -7,11 +7,6 @@ variable "name" {
   }
 }
 
-variable "access_policy_name" {
-  description = "name of the IAM policy to create that will be provide the ability to connect to the database as a user that will have read/write access."
-  type        = string
-}
-
 variable "app_access_policy_name" {
   description = "name of the IAM policy to create that will provide the service the ability to connect to the database as a user that will have read/write access."
   type        = string


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context

Cleanup : This config value isn't used anywhere.

## Testing

Ran `make infra-update-app-database APP_NAME=app ENVIRONMENT=dev` which shows a clean plan except the role manager which always shows as a change due to the timestamp trigger:

<img width="783" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/cb3dd9fb-d55b-46bf-a2ee-d44909337d3d">

Ran `make infra-update-app-service  APP_NAME=app ENVIRONMENT=dev` which shows a clean plan:

<img width="442" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/e9f6b7cf-cf68-40f4-a445-38b06d6b896c">
