### PR TITLE
Make infra service test cleanup more robust

### DIFF
--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 var uniqueId = strings.ToLower(random.UniqueId())
@@ -136,6 +137,14 @@ func EnableDestroyService(t *testing.T, terraformOptions *terraform.Options) {
 		},
 		WorkingDir: "../../",
 	})
+
+	// Clone the options and set targets to only apply to the buckets
+	terraformOptions, err := terraformOptions.Clone()
+	require.NoError(t, err)
+	terraformOptions.Targets = []string{
+		"module.service.aws_s3_bucket.access_logs",
+		"module.storage.aws_s3_bucket.storage",
+	}
 	terraform.Apply(t, terraformOptions)
 	fmt.Println("::endgroup::")
 }


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context

If there's an error in the terraform for the service layer, then the terraform apply fails, which means the cleanup step that sets force_destroy = true for the buckets will also fail since the cleanup also does a terraform apply. This change uses a targeted apply to make the cleanup step more robust. This is similar to the change in this PR — https://github.com/navapbc/template-infra/pull/487 — but for ci-infra-service.yml instead of template-only-ci-infra.yml.

## Testing

CI should cover this since this is just a change to CI
