### PR TITLE
Allow multiple apps to deploy concurrently

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
 
-concurrency: cd-${{ inputs.environment }}
+concurrency: cd-${{inputs.app_name}}-${{ inputs.environment }}
 
 jobs:
   # Don't need to call the build-and-publish workflow since the database-migrations


### PR DESCRIPTION
## Ticket

N/A

## Changes

see title

## Context for reviewers

Noticed that a project with multiple apps could not deploy concurrently. Removed this restriction.

## Testing

- [x] Deploy app from this branch (see [workflow run](https://github.com/navapbc/platform-test/actions/runs/7937586323))