### PR TITLE
Add object tagging permissions

### DIFF
--- a/infra/modules/storage/access-control.tf
+++ b/infra/modules/storage/access-control.tf
@@ -43,9 +43,12 @@ data "aws_iam_policy_document" "storage_access" {
   statement {
     actions = [
       "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
       "s3:GetObject",
       "s3:GetObjectAttributes",
+      "s3:GetObjectTagging",
       "s3:PutObject",
+      "s3:PutObjectTagging",
     ]
     effect    = "Allow"
     resources = ["arn:aws:s3:::${var.name}/*"]


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-infra/issues/552

## Changes

> What was added, updated, or removed in this PR.

## Context for reviewers

The ecs task could put files to S3 but couldn't add tags to those files. This change adds the permissions to add tags. This was discovered while working on another project.

## Testing

Applied the following Terraform plan
<img width="803" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/afd0282a-9296-4c99-87c4-ab1b981b77bf">

Saw that the role's policy got updated
<img width="701" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/35bbbff5-8329-4f06-9532-21bd4ffa93c3">

Went to [doc upload page and uploaded a file](http://app-dev-1637400692.us-east-1.elb.amazonaws.com/document-upload)
<img width="746" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/6ee7b753-9cac-4f5e-a523-e02b1e8bd8c4">

Saw that the file was uploaded
<img width="372" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/94737a96-3a5d-4e99-b8c4-a6c45db74580">
