### PR TITLE
Simplify secret definitions by replace ARNs with SSM param names

### DIFF
--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -64,11 +64,14 @@ data "aws_iam_policy_document" "task_executor" {
   }
 
   dynamic "statement" {
-    for_each = length(local.secrets) > 0 ? [1] : []
+    for_each = length(var.secrets) > 0 ? [1] : []
     content {
-      sid       = "SecretsAccess"
-      actions   = ["ssm:GetParameters"]
-      resources = local.secrets[*].valueFrom
+      sid     = "SecretsAccess"
+      actions = ["ssm:GetParameters"]
+      resources = [
+        for secret in var.secrets :
+        "arn:aws:ssm:*:*:parameter/${secret.ssm_param_name}"
+      ]
     }
   }
 }

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -66,9 +66,9 @@ data "aws_iam_policy_document" "task_executor" {
   dynamic "statement" {
     for_each = length(var.secrets) > 0 ? [1] : []
     content {
-      sid     = "SecretsAccess"
-      actions = ["ssm:GetParameters"]
-      resources = resources = local.secret_arn_patterns
+      sid       = "SecretsAccess"
+      actions   = ["ssm:GetParameters"]
+      resources = local.secret_arn_patterns
     }
   }
 }

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -68,10 +68,7 @@ data "aws_iam_policy_document" "task_executor" {
     content {
       sid     = "SecretsAccess"
       actions = ["ssm:GetParameters"]
-      resources = [
-        for secret in var.secrets :
-        "arn:aws:ssm:*:*:parameter/${replace(secret.ssm_param_name, "/^//", "")}"
-      ]
+      resources = resources = local.secret_arn_patterns
     }
   }
 }

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "task_executor" {
       actions = ["ssm:GetParameters"]
       resources = [
         for secret in var.secrets :
-        "arn:aws:ssm:*:*:parameter/${secret.ssm_param_name}"
+        "arn:aws:ssm:::parameter/${replace(secret.ssm_param_name, "/^//", "")}"
       ]
     }
   }

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "task_executor" {
       actions = ["ssm:GetParameters"]
       resources = [
         for secret in var.secrets :
-        "arn:aws:ssm:::parameter/${replace(secret.ssm_param_name, "/^//", "")}"
+        "arn:aws:ssm:*:*:parameter/${replace(secret.ssm_param_name, "/^//", "")}"
       ]
     }
   }

--- a/infra/modules/service/secrets.tf
+++ b/infra/modules/service/secrets.tf
@@ -9,6 +9,6 @@ locals {
 
   secret_arn_patterns = [
     for secret in var.secrets :
-    "arn:aws:ssm:*:*:parameter/${replace(secret.ssm_param_name, "/^//", "")}"
+    "arn:aws:ssm:*:*:parameter/${trimprefix(secret.ssm_param_name, "/")}"
   ]
 }

--- a/infra/modules/service/secrets.tf
+++ b/infra/modules/service/secrets.tf
@@ -1,14 +1,9 @@
-data "aws_ssm_parameter" "secret" {
-  for_each = { for secret in var.secrets : secret.name => secret }
-  name     = each.value.ssm_param_name
-}
-
 locals {
   secrets = [
     for secret in var.secrets :
     {
       name      = secret.name,
-      valueFrom = data.aws_ssm_parameter.secret[secret.name].arn
+      valueFrom = secret.ssm_param_name
     }
   ]
 }

--- a/infra/modules/service/secrets.tf
+++ b/infra/modules/service/secrets.tf
@@ -6,4 +6,9 @@ locals {
       valueFrom = secret.ssm_param_name
     }
   ]
+
+  secret_arn_patterns = [
+    for secret in var.secrets :
+    "arn:aws:ssm:*:*:parameter/${replace(secret.ssm_param_name, "/^//", "")}"
+  ]
 }


### PR DESCRIPTION
## Ticket

N/A

## Context for reviewers

Using the SSM param name instead of the ARN allows us to create the SSM parameter in parallel, which is useful in situations where the SSM parameter doesn't already exist before the environment is created. This is a current need on another project. 

## Testing

Spun up the service layer in a workspace `t-lyss` and checked the `/secrets` endpoint to make sure it still works

<img width="709" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/d576c8a5-5b40-491f-a922-d954d3ade2d0">
