### PR TITLE
Add app and ref to build workflow run name

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,4 +1,5 @@
 name: Build and Publish
+run-name: Build and Publish ${{ inputs.app_name }}:${{ inputs.ref }}
 
 on:
   workflow_call:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,5 +1,5 @@
-name: Build and Publish
-run-name: Build and Publish ${{ inputs.app_name }}:${{ inputs.ref }}
+name: Build and publish
+run-name: Build and publish ${{ inputs.app_name }}:${{ inputs.ref }}
 
 on:
   workflow_call:


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

When there are multiple apps, the build and publish workflow run name doesn't differentiate between them. This change adds the name and ref (branch or git hash) to the run name to improve developer experience.

## Testing

Run the build and publish workflow from this branch:
<img width="1315" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/5dbf6791-8937-452c-b0c8-538c05e4eefa">
