### PR TITLE
Derive app_name from module path

### DIFF
--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -1,5 +1,8 @@
 locals {
-  app_name              = "app"
+  # app_name is the name of the application which by convention should match the name of
+  # the folder under /infra that corresponds to the application
+  app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
+
   environments          = ["dev", "staging", "prod"]
   project_name          = module.project_config.project_name
   image_repository_name = "${local.project_name}-${local.app_name}"

--- a/infra/app/app-config/main.tf
+++ b/infra/app/app-config/main.tf
@@ -1,5 +1,5 @@
 locals {
-  # app_name is the name of the application which by convention should match the name of
+  # app_name is the name of the application, which by convention should match the name of
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 


### PR DESCRIPTION
## Ticket

N/A

## Changes

see title

## Context for reviewers

When changing the name of the application from the default of `app`, such as when adding multiple applications to a monorepo, developers often forget to modify the app_name config value in the app-config module. This change removes the need for that manual step by obtaining the app_name from the name of the folder containing the application's infrastructure code.

## Testing

Running `make infra-update-app-service` yields no changes
<img width="634" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/61e8338b-51f0-465e-bbfb-6335fb5fd637">
