### PR TITLE
Add AWS defaults to container definitions to produce clean tf plan

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -98,10 +98,13 @@ resource "aws_ecs_task_definition" "app" {
       portMappings = [
         {
           containerPort = var.container_port,
+          hostPort      = var.container_port,
+          protocol      = "tcp"
         }
       ],
       linuxParameters = {
         capabilities = {
+          add  = []
           drop = ["ALL"]
         },
         initProcessEnabled = true
@@ -114,6 +117,9 @@ resource "aws_ecs_task_definition" "app" {
           "awslogs-stream-prefix" = local.log_stream_prefix
         }
       }
+      mountPoints    = []
+      systemControls = []
+      volumesFrom    = []
     }
   ])
 


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/600

## Changes

see title

## Context for reviewers

Unclear when this started happening, it's possible it's related to when we upgraded either terraform or when we upgraded the AWS provider, but in any case the terraform plan in the service layer is always showing a diff now even after applying any changes. This change adds some AWS default parameters to container_definitions.json to cause the plan to show a clean diff.

## Testing

Before changes, terraform plan in service layer shows a diff that requires creating a new task definition, which requires spinning up new containers and spinning down old containers:
<img width="386" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/9485acfe-678f-42da-a507-d5e2ae01e8a6">


After changes:
<img width="641" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/83bfb5ed-9521-4f21-b43a-5cf06239184f">
