### PR TITLE
Fix build/publish concurrency group

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -27,7 +27,7 @@ jobs:
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    concurrency: ${{ github.action }}-${{ inputs.ref }}
+    concurrency: ${{ github.workflow }}-${{ github.sha }}
 
     permissions:
       contents: read


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/606

## Changes

see title

## Context for reviewers

See context in ticket

## Testing

Run the build and publish workflow twice in quick succession, see that one is queued: 
<img width="1302" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/a8b4ce7f-49ba-4ce4-bb2b-d66f10d17cec">

See that the first one finished and successfully pushed to ECR: https://github.com/navapbc/platform-test/actions/runs/9195889400/job/25292703026
<img width="1015" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/aa5f8428-d9bb-43a1-97e8-1467182350c2">

See that the second one sees that the image has already been published: https://github.com/navapbc/platform-test/actions/runs/9195891217/job/25292709408
<img width="596" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/c2709c47-e284-405d-ad73-59220d279160">
