### PR TITLE
Skip build step if image already published

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -43,19 +43,20 @@ jobs:
         id: check-image-published
         run: |
           IS_IMAGE_PUBLISHED=$(./bin/is-image-published.sh "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          echo "Is image published: $IS_IMAGE_PUBLISHED"
           echo "IS_IMAGE_PUBLISHED=$IS_IMAGE_PUBLISHED" >> "$GITHUB_OUTPUT"
 
       - name: Build release
-        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-build
 
       - name: Configure AWS credentials
-        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         uses: ./.github/actions/configure-aws-credentials
         with:
           app_name: ${{ inputs.app_name }}
           environment: shared
 
       - name: Publish release
-        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-publish

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,10 +24,23 @@ on:
         type: string
 
 jobs:
+  get-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
+    steps:
+      - name: Get commit hash
+        id: get-commit-hash
+        run: |
+          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          echo "Commit hash: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    concurrency: ${{ github.workflow }}-${{ github.sha }}
+    needs: get-commit-hash
+    concurrency: ${{ github.workflow }}-${{ needs.get-commit-hash.outputs.commit_hash }}
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Configure AWS credentials
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          app_name: ${{ inputs.app_name }}
+          environment: shared
+
       - name: Check if image is already published
         id: check-image-published
         run: |
@@ -49,13 +56,6 @@ jobs:
       - name: Build release
         if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         run: make APP_NAME=${{ inputs.app_name }} release-build
-
-      - name: Configure AWS credentials
-        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
-        uses: ./.github/actions/configure-aws-credentials
-        with:
-          app_name: ${{ inputs.app_name }}
-          environment: shared
 
       - name: Publish release
         if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,7 +40,6 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Configure AWS credentials
-        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == 'false'
         uses: ./.github/actions/configure-aws-credentials
         with:
           app_name: ${{ inputs.app_name }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,6 +30,9 @@ jobs:
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Get commit hash
         id: get-commit-hash
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,14 +26,6 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.sha }}
 
 jobs:
-  check-image-published:
-    name: Check if image is already published
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      id-token: write
-
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -23,12 +23,11 @@ on:
         required: true
         type: string
 
-concurrency: ${{ github.workflow }}-${{ github.sha }}
-
 jobs:
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
+    concurrency: ${{ github.workflow }}-${{ github.sha }}
 
     permissions:
       contents: read

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -23,11 +23,20 @@ on:
         required: true
         type: string
 
+concurrency: ${{ github.workflow }}-${{ github.sha }}
+
 jobs:
+  check-image-published:
+    name: Check if image is already published
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-latest
-    concurrency: ${{ github.workflow }}-${{ github.sha }}
 
     permissions:
       contents: read
@@ -38,14 +47,23 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Check if image is already published
+        id: check-image-published
+        run: |
+          IS_IMAGE_PUBLISHED=$(./bin/is-image-published.sh "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          echo "IS_IMAGE_PUBLISHED=$IS_IMAGE_PUBLISHED" >> "$GITHUB_OUTPUT"
+
       - name: Build release
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
         run: make APP_NAME=${{ inputs.app_name }} release-build
 
       - name: Configure AWS credentials
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
         uses: ./.github/actions/configure-aws-credentials
         with:
           app_name: ${{ inputs.app_name }}
           environment: shared
 
       - name: Publish release
+        if: steps.check-image-published.outputs.IS_IMAGE_PUBLISHED == '0'
         run: make APP_NAME=${{ inputs.app_name }} release-publish

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Checks if an image tag has already been published to the container repository
+# Prints 1 if so, 0 otherwise
+
+set -euo pipefail
+
+APP_NAME=$1
+GIT_REF=$2
+
+# Get commit hash
+IMAGE_TAG=$(git rev-parse "$GIT_REF")
+
+# Need to init module when running in CD since GitHub actions does a fresh checkout of repo
+terraform -chdir="infra/$APP_NAME/app-config" init > /dev/null
+terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
+IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
+REGION=$(./bin/current-region.sh)
+
+RESULT=""
+RESULT=$(aws ecr describe-images --repository-name "$IMAGE_REPOSITORY_NAME" --image-ids "imageTag=$IMAGE_TAG" --region "$REGION" 2> /dev/null ) || true
+if [ -n "$RESULT" ];then
+  echo "1"
+else
+  echo "0"
+fi

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -19,7 +19,7 @@ REGION=$(./bin/current-region.sh)
 RESULT=""
 RESULT=$(aws ecr describe-images --repository-name "$IMAGE_REPOSITORY_NAME" --image-ids "imageTag=$IMAGE_TAG" --region "$REGION" 2> /dev/null ) || true
 if [ -n "$RESULT" ];then
-  echo "1"
+  echo "true"
 else
-  echo "0"
+  echo "false"
 fi

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -16,10 +16,6 @@ terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
 IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
 REGION=$(./bin/current-region.sh)
 
-echo "$IMAGE_TAG"
-echo "$IMAGE_REPOSITORY_NAME"
-echo "$REGION"
-
 RESULT=""
 RESULT=$(aws ecr describe-images --repository-name "$IMAGE_REPOSITORY_NAME" --image-ids "imageTag=$IMAGE_TAG" --region "$REGION" 2> /dev/null ) || true
 if [ -n "$RESULT" ];then

--- a/bin/is-image-published.sh
+++ b/bin/is-image-published.sh
@@ -16,6 +16,10 @@ terraform -chdir="infra/$APP_NAME/app-config" apply -auto-approve > /dev/null
 IMAGE_REPOSITORY_NAME=$(terraform -chdir="infra/$APP_NAME/app-config" output -raw image_repository_name)
 REGION=$(./bin/current-region.sh)
 
+echo "$IMAGE_TAG"
+echo "$IMAGE_REPOSITORY_NAME"
+echo "$REGION"
+
 RESULT=""
 RESULT=$(aws ecr describe-images --repository-name "$IMAGE_REPOSITORY_NAME" --image-ids "imageTag=$IMAGE_TAG" --region "$REGION" 2> /dev/null ) || true
 if [ -n "$RESULT" ];then


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/610
Resolves https://github.com/navapbc/template-infra/issues/609

## Changes

- Skip build step if image already published
- Use commit hash of input.ref for build job concurrency

## Context for reviewers

The build-and-publish worklflow always builds the image and only checks if the image is already published when getting ready to publish. This change moves the published image check before the build step, allowing the workflow to skip the build step altogether if the build has already been published.

In addition, this change fixes the build job concurrency to use the commit hash of the commit being built, not the commit hash of the workflow.

## Testing

Ran build and publish workflow from this branch twice:
[1st time ran all the steps](https://github.com/navapbc/platform-test/actions/runs/9245996048)
[2nd time skipped build/publish steps](https://github.com/navapbc/platform-test/actions/runs/9245997208) and only took 10 seconds

<img width="667" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/342bce71-d798-4337-9b85-0c47043ed116">

To test the concurrency, I ran the job twice and showed that the second one was queued up waiting for the first to finish
<img width="1143" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/eac68f8e-3210-4729-bc72-bd8f5eaa5791">

To test that I can build two different commits simultaneously I ran it on two commits and you can see neither job is queued
- https://github.com/navapbc/platform-test/actions/runs/9246042530
- https://github.com/navapbc/platform-test/actions/runs/9246042823
<img width="1160" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/4a2cd08f-5fd5-492b-9dac-616f7488c1a8">
