### PR TITLE
Refine replace trigger for installation of role manager packages

### DIFF
--- a/infra/modules/database/role-manager.tf
+++ b/infra/modules/database/role-manager.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "role_manager" {
 # environment.
 # Timestamp is used to always trigger replacement.
 resource "terraform_data" "role_manager_python_vendor_packages" {
-  triggers_replace = timestamp()
+  triggers_replace = fileexists(local.role_manager_package) ? file("${path.module}/role_manager/requirements.txt") : timestamp()
   provisioner "local-exec" {
     command = "pip3 install -r ${path.module}/role_manager/requirements.txt -t ${path.module}/role_manager/vendor --upgrade"
   }


### PR DESCRIPTION
## Ticket

N/A

## Changes

see title

## Context for reviewers

Previously we only ran installation of role manager packages when the requirements.txt file changed, but this means that new infra engineers who ran terraform apply without having the packages installed locally would update the terraform lambda function to a zip file that didn't contain the dependencies, breaking the role manager.

In this PR https://github.com/navapbc/template-infra/pull/452/files we changed the package installation to always install, which fixed the issue but created an annoying situation where the terraform plan would always show changes to apply.

This change introduces a hybrid solution that works around the new engineer issue by triggering an installation of role manager packages locally if the zip archive doesn't exist locally. Otherwise it relies on changes to requirements.txt. It's not a perfect solution in that terraform apply needs to be run twice in order to get it into a stable state where the replacement trigger is set to the contents of requirements.txt, but it's an improvement over the previous two solutions.

## Testing

Did the following on the default workspace

Running `make infra-update-app-database` for the first time with zip file already existing
<img width="782" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/e55caa4f-0131-46dd-8a4d-1c356577e17e">

Running again shows clean plan
<img width="811" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/deae625f-7c11-4c27-bea5-502cff13f1f9">

Removed the zip file
<img width="538" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/d9437462-ba03-4211-9295-00297317389e">

Re-ran terraform apply
<img width="787" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/fb630c6e-f3d4-45f4-ad85-ca023067ae8c">

Re-running shows a diff one more time as the triggers_replace content gets switched back from the timestamp to the file contents of the requirements.txt file
<img width="788" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/95165bbf-399a-442c-85b4-bd034a7f0614">

Finally, re-running one last time shows a clean diff
<img width="812" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/06e821f5-a61e-44c7-abfc-0ee7d1506e80">
