### PR TITLE
Don't comment on PR after destroying PR environment

### DIFF
--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -33,5 +33,21 @@ terraform -chdir="infra/${app_name}/service" workspace select default
 echo "Delete workspace: ${workspace}"
 terraform -chdir="infra/${app_name}/service" workspace delete "${workspace}"
 
-echo "Post comment to PR confirming environment destruction"
-gh pr comment "${pr_number}" -b "Destroyed PR environment"
+pr_info=$(cat <<EOF
+<!-- begin PR environment info -->
+## Preview environment
+Environment destroyed
+<!-- end PR environment info -->
+EOF
+)
+
+pr_body="$(gh pr view "${pr_number}" --json body | jq --raw-output .body)"
+if [[ $pr_body == *"<!-- begin PR environment info -->"*"<!-- end PR environment info -->"* ]]; then
+  pr_body="${pr_body//<!-- begin PR environment info -->*<!-- end PR environment info -->/$pr_info}"
+else
+  pr_body="${pr_body}"$'\n\n'"${pr_info}"
+fi
+
+echo "Update PR description with PR environment info"
+echo "${pr_info}"
+gh pr edit "${pr_number}" --body "${pr_body}"

--- a/bin/destroy-pr-environment
+++ b/bin/destroy-pr-environment
@@ -36,7 +36,7 @@ terraform -chdir="infra/${app_name}/service" workspace delete "${workspace}"
 pr_info=$(cat <<EOF
 <!-- begin PR environment info -->
 ## Preview environment
-Environment destroyed
+♻️ Environment destroyed ♻️
 <!-- end PR environment info -->
 EOF
 )


### PR DESCRIPTION
## Ticket

n/a

## Changes

see title

## Context for reviewers

I think the PR environment destroyed comment is also noisy since it sends an email notification and it's never actionable.

## Testing

- Opened PR, waited for environment to be created. PR edited:

   <img width="633" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/2cba1ee8-f287-4cd9-b83e-17c103c0c841">

- Closed PR, waited for environment to be destroyed from [this run](https://github.com/navapbc/platform-test/actions/runs/9719777135), see PR description updated:

   <img width="615" alt="image" src="https://github.com/navapbc/platform-test/assets/447859/b16ec541-55b7-40d5-a6a5-d48be035afad">

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-120-app-dev-1279318780.us-east-1.elb.amazonaws.com
- Deployed commit: 8a2b2df9e5e09db4b6cda1c3984690c850e1c5d6
<!-- end PR environment info -->