### PR TITLE
Update task_executor IAM policy before running migrations

### DIFF
--- a/bin/run-database-migrations
+++ b/bin/run-database-migrations
@@ -45,7 +45,10 @@ migrator_role_arn=$(terraform -chdir="infra/$app_name/service" output -raw migra
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -target=module.service.aws_ecs_task_definition.app -var=image_tag=$image_tag" make infra-update-app-service APP_NAME="$app_name" ENVIRONMENT="$environment"
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$image_tag 
+  -target=module.service.aws_ecs_task_definition.app
+  -target=module.service.aws_iam_role_policy.task_executor" \
+  make infra-update-app-service APP_NAME="$app_name" ENVIRONMENT="$environment"
 
 echo "::endgroup::"
 echo

--- a/bin/run-database-migrations
+++ b/bin/run-database-migrations
@@ -23,32 +23,32 @@ echo "=================="
 echo "Running migrations"
 echo "=================="
 echo "Input parameters"
-echo "  app_name=$app_name"
-echo "  image_tag=$image_tag"
-echo "  environment=$environment"
+echo "  app_name=${app_name}"
+echo "  image_tag=${image_tag}"
+echo "  environment=${environment}"
 echo
 echo "Step 0. Check if app has a database"
 
-terraform -chdir="infra/$app_name/app-config" init > /dev/null
-terraform -chdir="infra/$app_name/app-config" apply -auto-approve > /dev/null
-has_database=$(terraform -chdir="infra/$app_name/app-config" output -raw has_database)
-if [ "$has_database" = "false" ]; then
+terraform -chdir="infra/${app_name}/app-config" init > /dev/null
+terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
+has_database=$(terraform -chdir="infra/${app_name}/app-config" output -raw has_database)
+if [ "${has_database}" = "false" ]; then
   echo "Application does not have a database, no migrations to run"
   exit 0
 fi
 
-db_migrator_user=$(terraform -chdir="infra/$app_name/app-config" output -json environment_configs | jq -r ".$environment.database_config.migrator_username")
+db_migrator_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.migrator_username")
 
-./bin/terraform-init "infra/$app_name/service" "$environment"
-migrator_role_arn=$(terraform -chdir="infra/$app_name/service" output -raw migrator_role_arn)
+./bin/terraform-init "infra/${app_name}/service" "${environment}"
+migrator_role_arn=$(terraform -chdir="infra/${app_name}/service" output -raw migrator_role_arn)
 
 echo
 echo "::group::Step 1. Update task definition without updating service"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$image_tag 
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=${image_tag} 
   -target=module.service.aws_ecs_task_definition.app
   -target=module.service.aws_iam_role_policy.task_executor" \
-  make infra-update-app-service APP_NAME="$app_name" ENVIRONMENT="$environment"
+  make infra-update-app-service APP_NAME="${app_name}" ENVIRONMENT="${environment}"
 
 echo "::endgroup::"
 echo
@@ -58,8 +58,8 @@ command='["db-migrate"]'
 
 # Indent the later lines more to make the output of run-command prettier
 environment_variables=$(cat << EOF
-[{ "name" : "DB_USER", "value" : "$db_migrator_user" }]
+[{ "name" : "DB_USER", "value" : "${db_migrator_user}" }]
 EOF
 )
 
-./bin/run-command --task-role-arn "$migrator_role_arn" --environment-variables "$environment_variables" "$app_name" "$environment" "$command"
+./bin/run-command --task-role-arn "${migrator_role_arn}" --environment-variables "${environment_variables}" "${app_name}" "${environment}" "${command}"

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -27,5 +27,9 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}-${var.environment}/secret-sauce"
     }
+    NEW_SECRET = {
+      manage_method     = "generated"
+      secret_store_name = "/${var.app_name}-${var.environment}/new-secret"
+    }
   }
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/675

## Changes

see title

## Context for reviewers

see ticket: https://github.com/navapbc/template-infra/issues/675

## Testing

1. To reproduce the error, I added a new secret in 220daed, then [ran a deploy from this branch](https://github.com/navapbc/platform-test/actions/runs/10049872582) which failed at the db migrations step:

   <img width="774" alt="image" src="https://github.com/user-attachments/assets/a9f3a6fc-dd0b-4a03-975f-d63932fea688">
   <img width="1545" alt="image" src="https://github.com/user-attachments/assets/e02d4e64-5b95-46d0-94f6-a0bd10b47632">

2. Then I made the change and [re-ran a deploy from this branch](https://github.com/navapbc/platform-test/actions/runs/10049926593), which succeeded

Note: The template-infra PR will not include the added test secret, which is only included here for testing purposes

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-127-app-dev-125880526.us-east-1.elb.amazonaws.com
- Deployed commit: bf33a88badb456c3e2d59ed03b8a8be5c66b4712
<!-- end PR environment info -->