### PR TITLE
Add input for which version to deploy on `Deploy App` workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,6 +12,10 @@ on:
         description: The branch, tag or SHA to checkout. When checking out the repository that triggered a workflow, this defaults to the reference or SHA for that event. Otherwise, use branch or tag that triggered the workflow run.
         required: true
         type: string
+    outputs:
+      commit_hash:
+        description: The SHA that was built
+        value: ${{ jobs.get-commit-hash.outputs.commit_hash }}
   workflow_dispatch:
     inputs:
       app_name:
@@ -63,7 +67,7 @@ jobs:
       - name: Check if image is already published
         id: check-image-published
         run: |
-          is_image_published=$(./bin/is-image-published "${{ inputs.app_name }}" "${{ inputs.ref }}")
+          is_image_published=$(./bin/is-image-published "${{ inputs.app_name }}" "${{ needs.get-commit-hash.outputs.commit_hash }}")
           echo "Is image published: $is_image_published"
           echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: Environment to be deployed to
+        description: Environment to deploy to
         required: true
         default: "dev"
         type: choice
@@ -25,7 +25,7 @@ on:
       version:
         required: true
         default: "main"
-        description: Tag or branch or SHA to be deployed
+        description: Tag or branch or SHA to deploy
 
 jobs:
   deploy:

--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -1,7 +1,7 @@
 name: Deploy App
 # Need to set a default value for when the workflow is triggered from a git push
 # which bypasses the default configuration for inputs
-run-name: Deploy ${{ github.ref_name }} to App ${{ inputs.environment || 'dev' }}
+run-name: Deploy ${{ inputs.version || 'main' }} to App ${{ inputs.environment || 'dev' }}
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "target environment"
+        description: Environment to be deployed to
         required: true
         default: "dev"
         type: choice
@@ -22,6 +22,10 @@ on:
           - dev
           - staging
           - prod
+      version:
+        required: true
+        default: "main"
+        description: Tag or branch or SHA to be deployed
 
 jobs:
   deploy:
@@ -30,3 +34,4 @@ jobs:
     with:
       app_name: "app"
       environment: ${{ inputs.environment || 'dev' }}
+      version: ${{ inputs.version || 'main' }}

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -11,6 +11,10 @@ on:
         description: "the name of the application environment (e.g. dev, staging, prod)"
         required: true
         type: string
+      version:
+        description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"
+        required: true
+        type: string
 
 concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }}
 
@@ -20,7 +24,7 @@ jobs:
     uses: ./.github/workflows/build-and-publish.yml
     with:
       app_name: ${{ inputs.app_name }}
-      ref: ${{ github.ref }}
+      ref: ${{ inputs.version }}
   run-migrations:
     name: Run migrations
     runs-on: ubuntu-latest
@@ -32,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -36,8 +36,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.version }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -50,4 +48,4 @@ jobs:
 
       - name: Run migrations
         run: |
-          make release-run-database-migrations APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }}
+          make release-run-database-migrations APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ inputs.version }}

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -18,7 +18,7 @@ on:
     outputs:
       commit_hash:
         description: The SHA that was used for migrations
-        value: ${{ jobs.get-commit-hash.outputs.commit_hash }}
+        value: ${{ jobs.build-and-publish.outputs.commit_hash }}
 
 concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }}
 

--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -15,6 +15,10 @@ on:
         description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"
         required: true
         type: string
+    outputs:
+      commit_hash:
+        description: The SHA that was used for migrations
+        value: ${{ jobs.get-commit-hash.outputs.commit_hash }}
 
 concurrency: database-migrations-${{ inputs.app_name }}-${{ inputs.environment }}
 
@@ -48,4 +52,4 @@ jobs:
 
       - name: Run migrations
         run: |
-          make release-run-database-migrations APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ inputs.version }}
+          make release-run-database-migrations APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ needs.build-and-publish.outputs.commit_hash }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ on:
         description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"
         required: true
         type: string
+    outputs:
+      commit_hash:
+        description: The SHA that was deployed
+        value: ${{ jobs.database-migrations.outputs.commit_hash }}
 
 concurrency: cd-${{inputs.app_name}}-${{ inputs.environment }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ on:
         description: "the name of the application environment (e.g. dev, staging, prod)"
         required: true
         type: string
+      version:
+        description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"
+        required: true
+        type: string
 
 concurrency: cd-${{inputs.app_name}}-${{ inputs.environment }}
 
@@ -23,6 +27,7 @@ jobs:
     with:
       app_name: ${{ inputs.app_name }}
       environment: ${{ inputs.environment }}
+      version: ${{ inputs.version }}
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -32,6 +37,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.version }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform
@@ -50,4 +48,4 @@ jobs:
           environment: ${{ inputs.environment }}
 
       - name: Deploy release
-        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }}
+        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ inputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
           environment: ${{ inputs.environment }}
 
       - name: Deploy release
-        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ inputs.version }}
+        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} IMAGE_TAG=${{ needs.database-migrations.outputs.commit_hash }}


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/693

## Changes

Pass the value along to the other workflows as necessary.

## Testing

Deploying with defaults (`dev` env and `main` version): https://github.com/navapbc/platform-test/actions/runs/10926380147

~Deploying this branch (which is functionally same as `main` at time of testing) to `dev` to see the different version get carried through and succeed: https://github.com/navapbc/platform-test/actions/runs/10926808599~ outdated

~Deploying this branch (which is functionally same as `main` at time of testing) to `dev` to see the different version get carried through and succeed
https://github.com/navapbc/platform-test/actions/runs/11000627559~ outdated


Deploying this branch (which is functionally same as `main` at time of testing) to `dev` to see the different version get carried through and succeed: https://github.com/navapbc/platform-test/actions/runs/11040058211

<!-- begin PR environment info -->
## Preview environment
- Service endpoint: http://p-137-app-dev-415399966.us-east-1.elb.amazonaws.com
- Deployed commit: 54559c3256065026290b80dd051aba6ed5e042fc
<!-- end PR environment info -->