### PR TITLE
Send notification for failed infra deploy status check

### DIFF
--- a/.github/workflows/check-infra-deploy-status.yml
+++ b/.github/workflows/check-infra-deploy-status.yml
@@ -69,3 +69,12 @@ jobs:
           echo "::endgroup::"
         env:
           TF_IN_AUTOMATION: "true"
+  notify:
+    name: Notify
+    needs: check
+    if: failure()
+    uses: ./.github/workflows/send-system-notification.yml
+    with:
+      channel: "workflow-failures"
+      message: "🔍 [Infrastructure state differs from configuration](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+    secrets: inherit


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/806

## Changes

see title

## Context for reviewers

Leveraging the previously added workflow to send notifications for failed infra status check workflow

## Testing

Ran the workflow from this branch: https://github.com/navapbc/platform-test/actions/runs/12643677486/job/35230043171

Showed up as this 🔒 [ Slack notification](https://nava.slack.com/archives/C03G1SWD9H7/p1736214681583839)

<img width="556" alt="image" src="https://github.com/user-attachments/assets/7e10fece-ee6a-4b6a-8755-7e9c43f41309" />

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-149-app-dev-1419816799.us-east-1.elb.amazonaws.com
- Deployed commit: d2f48c802a2381abb4102c3a508e3281ad5f915d
<!-- app - end PR environment info -->