### PR TITLE
Fix trigger for PR environment destroy workflow

### DIFF
--- a/.github/workflows/ci-app-pr-environment-destroy.yml
+++ b/.github/workflows/ci-app-pr-environment-destroy.yml
@@ -5,7 +5,7 @@ on:
       pr_number:
         required: true
         type: string
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
Fixes bug where PR environment destroy workflow is not triggered when there is a conflict with the base branch

## Ticket

Resolves https://github.com/navapbc/template-infra/issues/826

## Changes

see title

## Context for reviewers

see ticket. i looked into why PRs were being orphaned and discovered it's not because PR destroy workflow was failing but because it wasn't being triggered at all.

## Testing

I can't easily fix this by closing the PR because the new trigger runs the destroy/cleanup from the base `main` branch which has the wrong trigger.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-151-app-dev-1872182351.us-east-1.elb.amazonaws.com
- Deployed commit: 6f797eee29dc8acdd44512118a02394e1776d49f
<!-- app - end PR environment info -->