### PR TITLE
Fix notifications access from service

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -64,20 +64,14 @@ def document_upload():
     return f'<form method="post" action="{upload_url}" enctype="multipart/form-data">{additional_fields}<input type="file" name="file"><input type="submit"></form>'
 
 
-@app.get("/notifications")
-def notifications_get():
+@app.route("/email-notifications", methods=["GET", "POST"])
+def email_notifications():
+    if request.method == "POST":
+        to = request.form["to"]
+        subject = "Test notification"
+        message = "This is a system generated test notification. If you received this email in error, please ignore it."
+        notifications.send_email(to, subject, message)
     return f'<form method="post">Send test email to:<input type="email" name="to"><input type="submit"></form>'
-
-
-@app.post("/notifications")
-def notifications_post():
-    pinpoint_app_id = os.environ["AWS_PINPOINT_APP_ID"]
-    sender_email = os.environ["AWS_PINPOINT_SENDER_EMAIL"]
-    to = request.form["to"]
-    subject = "Test notification"
-    message = "This is a system generated test notification. If you received this email in error, please ignore it."
-    notifications.send_email(to, subject, message)
-    return redirect("/notifications", code=303)
 
 
 @app.route("/secrets")

--- a/app/app.py
+++ b/app/app.py
@@ -3,8 +3,9 @@ import os
 from datetime import datetime
 
 import click
-from flask import Flask, render_template
+from flask import Flask, redirect, render_template, request
 
+import notifications
 import storage
 from db import get_db_connection
 
@@ -61,6 +62,22 @@ def document_upload():
     )
     # Note: Additional fields should come first before the file and submit button
     return f'<form method="post" action="{upload_url}" enctype="multipart/form-data">{additional_fields}<input type="file" name="file"><input type="submit"></form>'
+
+
+@app.get("/notifications")
+def notifications_get():
+    return f'<form method="post">Send test email to:<input type="email" name="to"><input type="submit"></form>'
+
+
+@app.post("/notifications")
+def notifications_post():
+    pinpoint_app_id = os.environ["AWS_PINPOINT_APP_ID"]
+    sender_email = os.environ["AWS_PINPOINT_SENDER_EMAIL"]
+    to = request.form["to"]
+    subject = "Test notification"
+    message = "This is a system generated test notification. If you received this email in error, please ignore it."
+    notifications.send_email(to, subject, message)
+    return redirect("/notifications", code=303)
 
 
 @app.route("/secrets")

--- a/app/app.py
+++ b/app/app.py
@@ -70,6 +70,7 @@ def email_notifications():
         to = request.form["to"]
         subject = "Test notification"
         message = "This is a system generated test notification. If you received this email in error, please ignore it."
+        logger.info("Sending test email to %s", to)
         notifications.send_email(to, subject, message)
     return f'<form method="post">Send test email to:<input type="email" name="to"><input type="submit"></form>'
 

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -33,5 +33,6 @@ def send_email(to: str, subject: str, message: str):
             }
         }
     )
+    print(response)
 
     return response

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -1,0 +1,37 @@
+import os
+import boto3
+
+def send_email(to: str, subject: str, message: str):
+    pinpoint_client = boto3.client("pinpoint")
+    app_id = os.environ["AWS_PINPOINT_APP_ID"]
+
+    response = pinpoint_client.send_messages(
+        ApplicationId=app_id,
+        MessageRequest={
+            "Addresses": {
+                to: {
+                    "ChannelType": "EMAIL"
+                }
+            },
+            "MessageConfiguration": {
+                "EmailMessage": {
+                    "SimpleEmail": {
+                        "Subject": {
+                            "Charset": "UTF-8",
+                            "Data": subject
+                        },
+                        "HtmlPart": {
+                            "Charset": "UTF-8",
+                            "Data": message
+                        },
+                        "TextPart": {
+                            "Charset": "UTF-8",
+                            "Data": message
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    return response

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,6 +5,14 @@
   <body>
     <main>
       <h1>Hello, world</h1>
+      <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/health">Health</a></li>
+        <li><a href="/migrations">Migrations</a></li>
+        <li><a href="/document-upload">Document Upload</a></li>
+        <li><a href="/email-notifications">Email Notifications</a></li>
+        <li><a href="/secrets">Secrets</a></li>
+      </ul>
     </main>
   </body>
 </html>  

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -195,7 +195,10 @@ module "service" {
     },
     module.app_config.enable_identity_provider ? {
       identity_provider_access = module.identity_provider_client[0].access_policy_arn,
-    } : {}
+    } : {},
+    module.app_config.enable_notifications ? {
+      notifications_access = module.notifications[0].access_policy_arn,
+    } : {},
   )
 
   is_temporary = local.is_temporary

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -14,6 +14,12 @@ variable "enable_command_execution" {
   default     = false
 }
 
+variable "enable_notifications" {
+  type        = bool
+  description = "Whether the application(s) in this network need AWS Pinpoint access."
+  default     = false
+}
+
 variable "has_database" {
   type        = bool
   description = "Whether the application(s) in this network have a database. Determines whether to create VPC endpoints needed by the database layer."

--- a/infra/modules/network/vpc_endpoints.tf
+++ b/infra/modules/network/vpc_endpoints.tf
@@ -18,6 +18,9 @@ locals {
 
     # AWS services used by ECS Exec
     var.enable_command_execution ? ["ssmmessages"] : [],
+
+    # AWS services used by notifications
+    var.enable_notifications ? ["pinpoint", "email-smtp"] : [],
   )
 
   # S3 and DynamoDB use Gateway VPC endpoints. All other services use Interface VPC endpoints

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_policy" "access" {
-  name        = "pinpoint_policy"
-  description = "Policy for calling SendMessages and SendUsersMessages on Pinpoint app"
+  name        = "${var.name}-access"
+  description = "Policy for calling SendMessages and SendUsersMessages on Pinpoint app ${var.name}"
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -12,8 +12,7 @@ resource "aws_iam_policy" "access" {
           "mobiletargeting:SendMessages",
           "mobiletargeting:SendUsersMessages"
         ]
-        Resource = "*"
-        # Resource = "${aws_pinpoint_app.app.arn}/messages"
+        Resource = "${aws_pinpoint_app.app.arn}/messages"
       }
     ]
   })

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -19,8 +19,10 @@ resource "aws_iam_policy" "access" {
           "ses:SendEmail",
           "ses:SendRawEmail",
         ]
-        # Resource = var.domain_identity_arn
-        Resource = "*"
+        Resource = [
+          var.domain_identity_arn,
+          "arn:*:ses:*:*:configuration-set/*",
+        ]
       }
     ]
   })

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -19,7 +19,8 @@ resource "aws_iam_policy" "access" {
           "ses:SendEmail",
           "ses:SendRawEmail",
         ]
-        Resource = var.domain_identity_arn
+        # Resource = var.domain_identity_arn
+        Resource = "*"
       }
     ]
   })

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "access" {
-  name        = "${var.name}-access"
+  name        = "${var.name}-notifications-access"
   description = "Policy for calling SendMessages and SendUsersMessages on Pinpoint app ${var.name}"
 
   policy = jsonencode({
@@ -11,7 +11,7 @@ resource "aws_iam_policy" "access" {
           "mobiletargeting:SendMessages",
           "mobiletargeting:SendUsersMessages"
         ]
-        Resource = aws_pinpoint_app.app.arn
+        Resource = "${aws_pinpoint_app.app.arn}/messages"
       }
     ]
   })

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -8,11 +8,18 @@ resource "aws_iam_policy" "access" {
       {
         Effect = "Allow"
         Action = [
-          "ses:SendEmail",
           "mobiletargeting:SendMessages",
           "mobiletargeting:SendUsersMessages"
         ]
         Resource = "${aws_pinpoint_app.app.arn}/messages"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail",
+        ]
+        Resource = var.domain_identity_arn
       }
     ]
   })

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -1,0 +1,18 @@
+resource "aws_iam_policy" "access" {
+  name        = "pinpoint_policy"
+  description = "Policy for calling SendMessages and SendUsersMessages on Pinpoint app"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "mobiletargeting:SendMessages",
+          "mobiletargeting:SendUsersMessages"
+        ]
+        Resource = aws_pinpoint_app.app.arn
+      }
+    ]
+  })
+}

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -5,6 +5,7 @@ resource "aws_iam_policy" "access" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
+      # From https://docs.aws.amazon.com/pinpoint/latest/developerguide/permissions-actions.html#permissions-actions-apiactions-messages
       {
         Effect = "Allow"
         Action = [
@@ -13,6 +14,8 @@ resource "aws_iam_policy" "access" {
         ]
         Resource = "${aws_pinpoint_app.app.arn}/messages"
       },
+
+      # From https://docs.aws.amazon.com/pinpoint/latest/developerguide/permissions-ses.html
       {
         Effect = "Allow"
         Action = [

--- a/infra/modules/notifications/resources/access_control.tf
+++ b/infra/modules/notifications/resources/access_control.tf
@@ -8,10 +8,12 @@ resource "aws_iam_policy" "access" {
       {
         Effect = "Allow"
         Action = [
+          "ses:SendEmail",
           "mobiletargeting:SendMessages",
           "mobiletargeting:SendUsersMessages"
         ]
-        Resource = "${aws_pinpoint_app.app.arn}/messages"
+        Resource = "*"
+        # Resource = "${aws_pinpoint_app.app.arn}/messages"
       }
     ]
   })

--- a/infra/modules/notifications/resources/outputs.tf
+++ b/infra/modules/notifications/resources/outputs.tf
@@ -1,3 +1,7 @@
 output "app_id" {
   value = aws_pinpoint_app.app.application_id
 }
+
+output "access_policy_arn" {
+  value = aws_iam_policy.access.arn
+}

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -36,6 +36,9 @@ locals {
       for environment_config in app.environment_configs : true if environment_config.service_config.enable_command_execution == true && environment_config.network_name == var.network_name
     ])
   ])
+
+  # Whether any of the applications in the network has enabled notifications
+  enable_notifications = anytrue([for app in local.apps_in_network : app.enable_notifications])
 }
 
 terraform {
@@ -76,6 +79,7 @@ module "network" {
   has_database                            = local.has_database
   has_external_non_aws_service            = local.has_external_non_aws_service
   enable_command_execution                = local.enable_command_execution
+  enable_notifications                    = local.enable_notifications
 }
 
 module "domain" {


### PR DESCRIPTION
## Ticket

Contributes to https://github.com/navapbc/template-infra/issues/792

## Changes

Fix ability for ECS service to access Pinpoint:
- Add VPC endpoints for Pinpoint services
- Add IAM policy for accessing Pinpoint and SES to service

Also add notifications test endpoint to example app for testing:
- Add /notifications page where you can enter an email address and get a test notification to that email address
- Add links to the homepage to all the test pages in the example app

## Context for reviewers

I added /notifications endpoint since it will be useful to test changes to notifications infrastructure, but while testing I discovered some access bugs

## Testing

Applied changes to dev network to create the two VPC endpoints using
```
make infra-update-network NETWORK_NAME=dev
```

Tested locally
<img width="487" alt="image" src="https://github.com/user-attachments/assets/f0ce821f-2a05-446e-af90-2f774f84832b" />

Tested on the PR environment, you can too! (took a while to get the IAM permissions right)
<img width="615" alt="image" src="https://github.com/user-attachments/assets/35c1c067-801c-4ce4-a6de-c74b461421ea" />


<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-154-app-dev-2103568609.us-east-1.elb.amazonaws.com
- Deployed commit: f6d6a07a6ddec0a9c25682a1247d4ea1576d8cf8
<!-- app - end PR environment info -->