### PR TITLE
Organize service root module main.tf into separate files

### DIFF
--- a/infra/app/service/database.tf
+++ b/infra/app/service/database.tf
@@ -1,0 +1,19 @@
+locals {
+  database_config = local.environment_config.database_config
+}
+
+data "aws_rds_cluster" "db_cluster" {
+  count              = module.app_config.has_database ? 1 : 0
+  cluster_identifier = local.database_config.cluster_name
+}
+
+data "aws_iam_policy" "app_db_access_policy" {
+  count = module.app_config.has_database ? 1 : 0
+  name  = local.database_config.app_access_policy_name
+}
+
+data "aws_iam_policy" "migrator_db_access_policy" {
+  count = module.app_config.has_database ? 1 : 0
+  name  = local.database_config.migrator_access_policy_name
+}
+

--- a/infra/app/service/domain.tf
+++ b/infra/app/service/domain.tf
@@ -1,0 +1,14 @@
+locals {
+  domain_name    = local.service_config.domain_name
+  hosted_zone_id = local.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null
+}
+
+data "aws_acm_certificate" "certificate" {
+  count  = local.service_config.enable_https ? 1 : 0
+  domain = local.domain_name
+}
+
+data "aws_route53_zone" "zone" {
+  count = local.domain_name != null ? 1 : 0
+  name  = local.network_config.domain_config.hosted_zone
+}

--- a/infra/app/service/identity_provider.tf
+++ b/infra/app/service/identity_provider.tf
@@ -1,4 +1,6 @@
 locals {
+  identity_provider_config = local.environment_config.identity_provider_config
+
   # If this is a temporary environment, re-use an existing Cognito user pool. Otherwise, create a new one.
   identity_provider_user_pool_id = module.app_config.enable_identity_provider ? (
     local.is_temporary ? module.existing_identity_provider[0].user_pool_id : module.identity_provider[0].user_pool_id

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -40,13 +40,12 @@ locals {
   # Examples: pull request preview environments are temporary.
   is_temporary = terraform.workspace != "default"
 
-  build_repository_config                        = module.app_config.build_repository_config
-  environment_config                             = module.app_config.environment_configs[var.environment_name]
-  service_config                                 = local.environment_config.service_config
-  database_config                                = local.environment_config.database_config
-  incident_management_service_integration_config = local.environment_config.incident_management_service_integration
-  identity_provider_config                       = local.environment_config.identity_provider_config
-  notifications_config                           = local.environment_config.notifications_config
+  build_repository_config  = module.app_config.build_repository_config
+  environment_config       = module.app_config.environment_configs[var.environment_name]
+  service_config           = local.environment_config.service_config
+  database_config          = local.environment_config.database_config
+  identity_provider_config = local.environment_config.identity_provider_config
+  notifications_config     = local.environment_config.notifications_config
 
   network_config = module.project_config.network_configs[local.environment_config.network_name]
 
@@ -98,13 +97,6 @@ data "aws_iam_policy" "app_db_access_policy" {
 data "aws_iam_policy" "migrator_db_access_policy" {
   count = module.app_config.has_database ? 1 : 0
   name  = local.database_config.migrator_access_policy_name
-}
-
-# Retrieve url for external incident management tool (e.g. Pagerduty, Splunk-On-Call)
-
-data "aws_ssm_parameter" "incident_management_service_integration_url" {
-  count = module.app_config.has_incident_management_service ? 1 : 0
-  name  = local.incident_management_service_integration_config.integration_url_param_name
 }
 
 data "aws_security_groups" "aws_services" {
@@ -202,15 +194,4 @@ module "service" {
   )
 
   is_temporary = local.is_temporary
-}
-
-module "monitoring" {
-  source = "../../modules/monitoring"
-  #Email subscription list:
-  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
-
-  # Module takes service and ALB names to link all alerts with corresponding targets
-  service_name                                = local.service_name
-  load_balancer_arn_suffix                    = module.service.load_balancer_arn_suffix
-  incident_management_service_integration_url = module.app_config.has_incident_management_service && !local.is_temporary ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
 }

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -17,11 +17,9 @@ locals {
   # Examples: pull request preview environments are temporary.
   is_temporary = terraform.workspace != "default"
 
-  build_repository_config  = module.app_config.build_repository_config
-  environment_config       = module.app_config.environment_configs[var.environment_name]
-  service_config           = local.environment_config.service_config
-  identity_provider_config = local.environment_config.identity_provider_config
-  notifications_config     = local.environment_config.notifications_config
+  build_repository_config = module.app_config.build_repository_config
+  environment_config      = module.app_config.environment_configs[var.environment_name]
+  service_config          = local.environment_config.service_config
 
   service_name = "${local.prefix}${local.service_config.service_name}"
 }

--- a/infra/app/service/monitoring.tf
+++ b/infra/app/service/monitoring.tf
@@ -1,0 +1,21 @@
+locals {
+  incident_management_service_integration_config = local.environment_config.incident_management_service_integration
+}
+
+# Retrieve url for external incident management tool (e.g. Pagerduty, Splunk-On-Call)
+
+data "aws_ssm_parameter" "incident_management_service_integration_url" {
+  count = module.app_config.has_incident_management_service ? 1 : 0
+  name  = local.incident_management_service_integration_config.integration_url_param_name
+}
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+  #Email subscription list:
+  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
+
+  # Module takes service and ALB names to link all alerts with corresponding targets
+  service_name                                = local.service_name
+  load_balancer_arn_suffix                    = module.service.load_balancer_arn_suffix
+  incident_management_service_integration_url = module.app_config.has_incident_management_service && !local.is_temporary ? data.aws_ssm_parameter.incident_management_service_integration_url[0].value : null
+}

--- a/infra/app/service/network.tf
+++ b/infra/app/service/network.tf
@@ -1,0 +1,38 @@
+locals {
+  network_config = module.project_config.network_configs[local.environment_config.network_name]
+}
+
+data "aws_vpc" "network" {
+  tags = {
+    project      = module.project_config.project_name
+    network_name = local.environment_config.network_name
+  }
+}
+
+data "aws_subnets" "public" {
+  tags = {
+    project      = module.project_config.project_name
+    network_name = local.environment_config.network_name
+    subnet_type  = "public"
+  }
+}
+
+data "aws_subnets" "private" {
+  tags = {
+    project      = module.project_config.project_name
+    network_name = local.environment_config.network_name
+    subnet_type  = "private"
+  }
+}
+
+data "aws_security_groups" "aws_services" {
+  filter {
+    name   = "group-name"
+    values = ["${module.project_config.aws_services_security_group_name_prefix}*"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.network.id]
+  }
+}

--- a/infra/app/service/notifications.tf
+++ b/infra/app/service/notifications.tf
@@ -1,4 +1,6 @@
 locals {
+  notifications_config = local.environment_config.notifications_config
+
   # If this is a temporary environment, re-use an existing email identity. Otherwise, create a new one.
   domain_identity_arn = local.notifications_config != null ? (
     !local.is_temporary ?


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/645

## Changes

- Move incident management resources into monitoring.tf
- Move database related resources into database.tf
- Move VPC related resources into network.tf
- Move custom domain related resources into domain.tf
- Move identity_provider_config variable to identity_provider.tf
- Move notifications_config variable to notifications.tf

## Context

The main.tf file for the service layer root module (/infra/{{app_name}}/service) was getting unwieldy, making it hard to read, hard to find specific resources, and also increases the chance of conflicts for projects that need to add customizations to the service layer. This change splits main.tf into separate files based on logical groupings.

## Testing

`make infra-update-app-service APP_NAME=app ENVIRONMENT=dev` shows no changes
<img width="432" alt="image" src="https://github.com/user-attachments/assets/c65429b5-a431-4e80-8ba5-f0888c1acfe4" />

`AWS_PROFILE=platform-test-prod make infra-update-app-service APP_NAME=app ENVIRONMENT=prod` shows no changes as well
<img width="427" alt="image" src="https://github.com/user-attachments/assets/1e8976bd-5180-4ef4-9205-8083b68d0676" />

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-155-app-dev-1534209605.us-east-1.elb.amazonaws.com
- Deployed commit: 93f11a32be4df26705fcf2ddfc68015f4a6d57bc
<!-- app - end PR environment info -->