### PR TITLE
Fix db migrations

### DIFF
--- a/bin/run-database-migrations
+++ b/bin/run-database-migrations
@@ -37,9 +37,8 @@ if [ "${has_database}" = "false" ]; then
   exit 0
 fi
 
-db_migrator_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.migrator_username")
-
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
+db_migrator_user=$(terraform -chdir="infra/${app_name}/service" output -raw migrator_username)
 migrator_role_arn=$(terraform -chdir="infra/${app_name}/service" output -raw migrator_role_arn)
 
 echo

--- a/infra/app/service/outputs.tf
+++ b/infra/app/service/outputs.tf
@@ -10,6 +10,10 @@ output "migrator_role_arn" {
   value = module.service.migrator_role_arn
 }
 
+output "migrator_username" {
+  value = module.app_config.has_database ? module.database[0].migrator_username : null
+}
+
 output "service_cluster_name" {
   value = module.service.cluster_name
 }

--- a/infra/modules/database/data/outputs.tf
+++ b/infra/modules/database/data/outputs.tf
@@ -18,6 +18,10 @@ output "migrator_access_policy_arn" {
   value = data.aws_iam_policy.migrator_db_access_policy.arn
 }
 
+output "migrator_username" {
+  value = module.interface.migrator_username
+}
+
 output "port" {
   value = data.aws_rds_cluster.db_cluster.port
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/845

## Changes

see title

## Context for reviewers

see ticket, after removing migrator username from app-config the run db migrations script now thinks migrator username is null

## Testing

run `make release-run-database-migrations APP_NAME=app ENVIRONMENT=dev` worked 

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-160-app-dev-1966235147.us-east-1.elb.amazonaws.com
- Deployed commit: b4c27661dc9a7e91930dc520ecb611122210f2ec
<!-- app - end PR environment info -->