### PR TITLE
Fix concurrency group in build and publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -48,7 +48,7 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     needs: get-commit-hash
-    concurrency: ${{ github.workflow }}-${{ inputs.app_name }}-${{ needs.get-commit-hash.outputs.commit_hash }}
+    concurrency: build-and-publish-${{ inputs.app_name }}-${{ needs.get-commit-hash.outputs.commit_hash }}
 
     permissions:
       contents: read


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/836

## Changes

see title

## Context for reviewers

Previous fix https://github.com/navapbc/template-infra/pull/848 didn't quite fix the race condition (see https://github.com/navapbc/platform-test/actions/runs/12917748724/attempts/1). I think it’s because the github.workflow in the concurrency group refers to the parent workflow, which is different, so cd-app.yml and ci-app-infra-service.yml both calling build-and-publish.yml workflow would produce different concurrency groups.

## Testing

CI to make sure things still work. We'll test out the race condition on future merges.