### PR TITLE
New image scanning workflow and parsing

### DIFF
--- a/.github/ISSUE_TEMPLATE/image-scan-findings.md
+++ b/.github/ISSUE_TEMPLATE/image-scan-findings.md
@@ -1,0 +1,25 @@
+---
+name: Image Scan Template
+about: Describes any findings in a Docker image scanned by the image-scan action
+# Will create an issue where the title is like the following format
+# Image Scan Findings April 2025 - APP_NAME
+# If this issue title already exists, the workflow will update this issue
+title: Image Scan Findings {{ date | date('MMMM YYYY') }} - {{ env.APP_NAME }}
+# Auto adds these labels on issue creation, the image_scan_findings and API Guild
+# label are required for Github project automation to put the issue in the right
+# board view
+labels: dependencies, image_scan_findings, API Guild
+assignees: ""
+---
+
+#  Image Scan
+
+## Background
+
+This issue is auto-created by the image-scans.yml workflow. It will update with any findings when the daily run is triggered as long as this issue is open and in the same month. If this issue is closed, or the workflow runs in a new month, it will open a new issue for any findings.
+
+{{ env.IMAGE_FINDINGS }}
+
+## Image Scan Link
+
+[Click here to review logs from workflow run if needed]({{ env.WORKFLOW_LINK }})

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -1,0 +1,78 @@
+name: Image Security and Vulnerability Scan
+description: Run image vulnerability scans
+
+inputs:
+  image-tag:
+    required: true
+    type: string
+    description: The image tag that will be scanned
+  dockerfile:
+    required: true
+    type: string
+    description: The location of the Dockerfile that will be scanned
+
+# Version is pinned to keep the JSON format consistent. If this is updated, 
+# and the findings parsing fails, then you need to update the python file. 
+# Dependabot can be configured to monitor these versions so you can get automatic
+# PRs to update the version, and check that the changes don't break parsing
+
+runs:
+  # Running on composite so that we can build the image once, but run multiple tests on it
+  using: "composite"
+  steps:
+    # Scans Dockerfile for any bad practices or issues
+    - name: Scan app Dockerfile by hadolint
+      uses: hadolint/hadolint-action@v3.1.0
+      with:
+        dockerfile: ${{ inputs.dockerfile }}
+        format: json
+        failure-threshold: warning
+        output-file: hadolint.json
+
+    - name: Anchore - Scan the release image
+      if: always() # Runs even if there is a failure
+      uses: anchore/scan-action@v6.0.0
+      id: anchore-scan
+      with:
+        image: ${{ inputs.image-tag }}
+        severity-cutoff: negligible
+        output-format: json
+        output-file: anchore.json
+
+    - name: Get current date
+      id: date
+      shell: bash
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Check for Trivy cache
+      id: cache-check
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.cache/trivy
+        key: cache-trivy-${{ steps.date.outputs.date }}
+        restore-keys: cache-trivy-
+        lookup-only: true
+
+    - name: Trivy - Scan the release image
+      if: always() # Runs even if there is a failure
+      uses: aquasecurity/trivy-action@0.26.0
+      with:
+        scan-type: image # Scan type, image or fs
+        image-ref: ${{ inputs.image-tag }}
+        format: json # Can be table, json, sarif, or github
+        output: trivy.json
+        exit-code: 1 # Exit code to return if any vulnerabilities are found
+        ignore-unfixed: true # Ignore unpatched/unfixed vulnerabilities
+        vuln-type: os,library # Can be os or library, depending on the type of scan you want to run
+        scanners: vuln,secret,config
+        trivy-config: trivy.yaml
+        # Enables caching of trivy config file that is used to search for the
+        # vulnerabilities. We cache it since it only updates once every 6 hours,
+        # and the confg hosts can be down, causing failures
+        cache: 'true'
+      env:
+        # Set to skip since we cache the files in the vulnerability-update-cache
+        # workflow. The if else logic handles when the cache doesn't exist, it
+        # will cache the config file so we can skip in the future
+        TRIVY_SKIP_DB_UPDATE: ${{ steps.cache-check.outputs.cache-hit != 'true' && 'false' || 'true' }}
+        TRIVY_SKIP_JAVA_DB_UPDATE: ${{ steps.cache-check.outputs.cache-hit != 'true' && 'false' || 'true' }}

--- a/.github/workflows/ci-vulnerability-scans.yml
+++ b/.github/workflows/ci-vulnerability-scans.yml
@@ -1,0 +1,82 @@
+# This workflow will scan the release versions of your Docker images, and standardize the results into a JSON file. This file
+# can be used to create Github tickets and Slack alerts
+
+name: Template Release Image Scans
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  pull_request:
+    paths:
+      # Handles when there are changes to the ignore files
+      - .grype.yml        # Anchore ignore
+      - .hadolint.yaml    # Hadolint ignore
+      - .trivyignore.yaml # Trivy ignore
+      - trivy.yaml        # Trivy config that points to the ignore file
+      # Handles when there are changes to the actual workflows we use
+      - .github/workflows/ci-vulnerability-scans.yml
+      - .github/workflows/vulnerability-scans.yml
+      - .github/actions/image-scan/action.yml
+      # Add paths to monitor for changes that should trigger a scan
+      ## Set for this example repo
+      - app/Dockerfile
+      - app/requirements.txt
+      - app/.dockerignore
+      - app-rails/Dockerfile
+      - app-rails/Gemfile
+      - app-rails/Gemfile.lock
+      - app-rails/package.json
+      - app-rails/package-lock.json
+      - app-rails/.dockerignore
+    # So we can run this workflow manually
+    workflow_dispatch:
+
+# These permissions are needed for opening Github tickets, remove comments if that functionality is enabled
+# permissions:
+#     contents: read
+#     issues: write
+
+jobs:
+  matrix_image_scans:
+    # Setting to new in case there's anything checking the existing vulnerability-scans.yml
+    # This will be fixed before merging
+    uses: ./.github/workflows/new-vulnerability-scans.yml
+    strategy:
+      # Lets all jobs run instead of cancelling if one of them fails
+      fail-fast: false
+      matrix:
+        application:
+          # Here you can define a list of applications that you want to scan. The format expected is as follows
+          # - app_dir: The directory where the Makefile to run the command make release-build in
+          #   app_name: A cleaned name to use for alerting purposes. An example could be something like "Flask Backend API"
+          #   dockerfile: The path to and name of the Dockerfile to scan. An example would be something like api/prod.Dockerfile
+          #   github_runner: The runner to use in the Github runner. The default is ubuntu-latest, but you can specify other runners if needed. For example, macos-latest or windows-latest.
+          #   virtualize_arm: Boolean for whether to virtualize the ARM architecture for the scanner. This should be set to true if the Dockerfile uses an ARM based image.
+
+          # Here is an example to scan the Temporal server image in a nested directory. The base image is ARM, so we need to virtualize
+          # - app_dir: temporal-cluster
+          #   app_name: "Temporal Server (frontend, history, matching, worker)"
+          #   dockerfile: temporal-cluster/server.Dockerfile
+          #   github_runner: ubuntu-latest
+          #   virtualize_arm: "true"
+          - app_dir: app
+            app_name: "Example Python app"
+            dockerfile: app/Dockerfile
+            github_runner: ubuntu-latest
+            virtualize_arm: "false"
+          - app_dir: app-rails
+            app_name: "Example rails app"
+            dockerfile: app-rails/Dockerfile
+            github_runner: ubuntu-latest
+            virtualize_arm: "false"
+
+    with:
+      runner: ${{ matrix.application.runner }}
+      virtualize_arm: ${{ matrix.application.virtualize_arm }}
+      app_dir: ${{ matrix.application.app_dir }}
+      dockerfile: ${{ matrix.application.dockerfile }}
+      app_name: ${{ matrix.application.app_name }}
+      # Alerting and ticket creation variables, disabled by default since not all alerting methods are used, 
+      # or require setup before enabling
+      alert_slack: "false"
+      create_github_ticket: "false"

--- a/.github/workflows/new-vulnerability-scans.yml
+++ b/.github/workflows/new-vulnerability-scans.yml
@@ -1,0 +1,133 @@
+name: Release image scans
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        # Defaults to using the x86 version of the Ubuntu runner
+        default: ubuntu-latest
+      # If you are using an x86 runner, and are building an ARM image, this input needs to be set to true.
+      # The runner will run slow or fail trying to build ARM images. Set this to false if
+      # the runner is an ARM based runner, ie - arm-linux-runner
+      virtualize_arm:
+        type: string
+        default: "true"
+      # The directory where the code is located in the repository. If it's not at the root, specify the path here. 
+      # This will tell the workflow where the Makefile with the correct command to build the image is located
+      app_dir:
+        type: string
+        default: ""
+      # The path to the Dockerfile, including the Dockerfile name
+      dockerfile:
+        type: string
+        default: ""
+      # The name of the application, used for alerting. This should be something that makes it obvious what application is being scanned.
+      app_name:
+        type: string
+        default: ""
+      # Alerting or ticket creation enabled variables, disabled by default
+      alert_slack:
+        type: string
+        default: "false"
+      create_github_ticket:
+        type: string
+        default: "false"
+
+# These permissions are needed for opening tickets
+permissions:
+    contents: read
+    issues: write
+
+env:
+  # This is used to format the findings output. Options are
+  #   - github_markdown (Will work with Github tickets, workflow outputs, etc. Might work for other Markdown viewers, but is untested)
+  findings_format: github_markdown
+
+jobs:
+  release-image-scans:
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Qemu for ARM virtualization image builds
+        uses: docker/setup-qemu-action@v3.2.0
+        if: ${{ inputs.virtualize_arm == 'true' }}
+
+      - name: Build the release image
+        env:
+          APP_DIR: ${{ inputs.app_dir }}
+          ECR_REGISTRY: image
+          ECR_REPOSITORY: scans
+          IMAGE_TAG: workflow
+        run: |
+          make release-build
+
+      - name: Run image scanning suite
+        uses: ./.github/actions/image-scan
+        timeout-minutes: 10
+        with:
+          image-tag: image/scans:workflow
+          dockerfile: ${{ inputs.dockerfile }}
+
+      - name: Format findings to Github markdown and display in step summary
+        if: ${{ always() }}
+        id: formatted_findings
+        env:
+          APP_NAME: ${{ inputs.app_name }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          FINDINGS_FORMAT: ${{ env.findings_format }}
+        run: |
+          python3 bin/image_scans/parse_findings.py
+          cat github_markdown.md >> "$GITHUB_STEP_SUMMARY"
+          echo "FINDINGS<<EOF" >> "$GITHUB_OUTPUT"
+          cat markdown.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      # Github specific ticket creation step
+      # This is disabled because it requires using Github for ticket management. If you plan on using this, it will create a ticket
+      # in the repo this workflow runs from. If you would like it to automatically get added to a Github board, then you would need
+      # to create a board workflow that takes any issues created in this repo with a specific label and adds them to that board.
+      - name: Create Github ticket with findings
+        if: ${{ failure() && inputs.create_github_ticket == 'true' }}
+        id: create_github_ticket
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # These variables are used to sub in the template file
+          APP_NAME: ${{ inputs.app_name }}
+          IMAGE_FINDINGS: ${{ steps.formatted_findings.outputs.FINDINGS }}
+          WORKFLOW_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/image-scan-findings.md
+          # Allows us to reuse the same ticket instead of opening new ones each time
+          update_existing: true
+          # Only update open issues, otherwise we update closed ones
+          search_existing: open
+
+      # Slack specific alerting steps
+      # This is disabled because to use this, you need to create a Slack webhook that is expecting this payload, and save
+      # the webhook URL as a secret in your repository. This is not enabled by default because it requires additional setup
+      - name: Decide what link to use for Slack alerting
+        if: ${{ failure() && inputs.alert_slack == 'true' }}
+        id: slack_link
+        run: |
+          SLACK_ALERT_LINK="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ inputs.create_github_ticket }}" == "true" ]; then
+            SLACK_ALERT_LINK="${{ steps.create_github_ticket.outputs.url }}"
+          fi
+          echo "SLACK_ALERT_LINK=$SLACK_ALERT_LINK" >> $GITHUB_OUTPUT
+
+      - name: Alert Slack
+        if: ${{ failure() && inputs.alert_slack == 'true' }}
+        uses: slackapi/slack-github-action@v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.IMAGE_SCAN_NOTIFICATION_SLACK_URL }}
+        with:
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "APPLICATION": "${{ inputs.app_name }}",
+              "LINK": "${{ steps.slack_link.outputs.SLACK_ALERT_LINK }}"
+            }

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,40 @@
+# https://aquasecurity.github.io/trivy/v0.56/docs/configuration/filtering/#trivyignoreyaml
+# Remove comment to add ignores for any vulnerabilities
+# vulnerabilities:
+  # List of vulnerabilities to ignore for the trivy scan
+  # Please add ignore in the following format to make it easier when checking
+  # Package/module name: URL to vulnerability for checking updates
+  #  Versions:     URL to the version history
+  #  Dependencies: Name of any other packages or modules that are dependent on this version
+  #                 Link to the dependencies for ease of checking for updates
+  #  Issue:         Why there is a finding and why this is here or not been removed
+  #  Last checked:  Date last checked in scans
+  #  - id: The-CVE-or-vuln-id # Remove comment at start of line
+  #     expire_at: YYYY-MM-DD # Optional: When to set this ignore to expire at and then it will be checked again
+  #     statment: Blah # Optional: Statement to why this is ignored, shows in logs
+  #     paths: /path/to/finding # Optional: Lets you scope the ignore down to a specific path so you aren't skipping it globally
+
+# Remove comment to add ignores for any misconfigurations
+# misconfigurations:
+  # Please add ignores in the following format to make it easier when checking
+  # Category: The category of the secret
+  # Issue: What the finding is and we are ignoring this finding
+  # Links: (If any) links to documentation
+
+# Remove comment to add ignores for any secrets
+# secrets:
+  # Adds ignores for what trivy thinks are secrets, but aren't really. If you add
+  # an ignore here, you MUST scope it down to the specific path or it will skip
+  # at a global level
+  # Please add ignores in the following format to make it easier when checking
+  # Category: The category of the secret
+  # Issue: What the finding is and we are ignoring this finding
+  # Links: (If any) links to documentation
+
+  # Example
+  # Category: JWT Token
+  # Issue: Trivy is finding the documentation for python_jose and thinks the "secret"
+  #        it found is an actual JWT, so we need to ignore it
+  # - id: jwt-token
+  #   paths:
+  #     - "/app/.venv/lib/python3.11/site-packages/python_jose-3.3.0.dist-info/METADATA"

--- a/bin/image_scans/github.py
+++ b/bin/image_scans/github.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+
+def create_markdown(payload: dict, filename: str) -> None:
+    # Handles printing out what app these findings are for
+    app_name = os.getenv("APP_NAME")
+
+    with open(filename, "w") as output:
+        output.write(f"## {app_name}\n\n")
+
+        for key, findings in payload.items():
+            # Handles skipping if the findings are empty
+            if not findings:
+                continue
+            # Shows the top level key as a header
+            output.write(f"### {key}\n")
+            for source in findings:
+                output.write("<details>\n")
+                output.write(f"<summary>{source}</summary>\n\n")
+                for vulnerability in findings[source]:
+                    # Handles setting the emoji based on severity
+                    emoji = ""
+                    if vulnerability["severity"].lower() == "critical":
+                        emoji = ":rotating_light: :rotating_light: :rotating_light:"
+                    if vulnerability["severity"].lower() in ["high", "error"]:
+                        emoji = ":rotating_light:"
+                    elif vulnerability["severity"].lower() in ["medium", "warning"]:
+                        emoji = ":warning:"
+
+                    output.write(
+                        f"#### {emoji} {vulnerability['severity']}: {vulnerability['id']} - {vulnerability['status']}\n"
+                    )
+                    output.write(f"Cause - {vulnerability['cause']}\n")
+                    output.write(f"Description - {vulnerability['description']}\n\n")
+                output.write("</details>\n\n")
+            output.write("\n\n")
+    return

--- a/bin/image_scans/parse_findings.py
+++ b/bin/image_scans/parse_findings.py
@@ -1,0 +1,137 @@
+import json
+import os
+
+from github import create_markdown as create_github_markdown
+
+
+def parse_trivy():
+    scan_results = {}
+
+    file_location = os.environ.get("TRIVY_RESULTS_FILE", "trivy.json")
+    if not os.path.exists(file_location):
+        print("ERROR: Trivy file not found!")
+        return scan_results
+
+    with open(file_location) as findings:
+        findings = json.load(findings)
+        for result in findings["Results"]:
+            # If there are vulnerabilities in the result
+            if "Vulnerabilities" in result:
+                package_name = result["Target"]
+                # For handling if the vulnerability is in the poetry venv. We don't
+                # need to see the path to the vulnerability, just what the package is
+                # Custom cleaning can be done here to make the output cleaner
+                # For example, removing the path to the poetry venv from the package name. Uncomment and modify as needed.
+                # package_name = package_name.replace(
+                #     "app/.venv/lib/python3.11/site-packages/", ""
+                # )
+
+                if package_name not in scan_results:
+                    scan_results[package_name] = []
+                for line in result["Vulnerabilities"]:
+                    scan_results[package_name].append(
+                        {
+                            "id": line["VulnerabilityID"],
+                            "severity": line["Severity"],
+                            "status": line["Status"],
+                            "cause": f"Current version: {line['InstalledVersion']}, fixed version(s): {line['FixedVersion']}",
+                            # Handles if there's markdown in the description, we want to pull the description before markdown
+                            "description": line["Description"].split("##")[0],
+                        }
+                    )
+    return scan_results
+
+
+def parse_anchore():
+    scan_results = {}
+
+    file_location = os.environ.get("ANCHORE_RESULTS_FILE", "anchore.json")
+    if not os.path.exists(file_location):
+        print("ERROR: Anchore file not found!")
+        return scan_results
+
+    with open(file_location) as findings:
+        findings = json.load(findings)
+        for result in findings["matches"]:
+            package_name = result["artifact"]["name"]
+            if package_name not in scan_results:
+                scan_results[package_name] = []
+            for line in result["matchDetails"]:
+                # The description can sometimes be missing, so we need to handle it
+                description = "Finding has no description"
+                if "description" in result["vulnerability"]:
+                    description = result["vulnerability"]["description"]
+
+                scan_results[package_name].append(
+                    {
+                        "id": line["found"]["vulnerabilityID"],
+                        "severity": result["vulnerability"]["severity"],
+                        "status": result["vulnerability"]["fix"]["state"],
+                        "cause": f"Current version: {result['artifact']['version']}, fixed version(s): {result['vulnerability']['fix']['versions']}",
+                        "description": description,
+                    }
+                )
+
+    return scan_results
+
+
+def parse_hadolint():
+    scan_results = {}
+
+    file_location = os.environ.get("HADOLINT_RESULTS_FILE", "hadolint.json")
+    if not os.path.exists(file_location):
+        print("ERROR: Hadolint file not found!")
+        return scan_results
+
+    # Possible finding levels from the hadolint results
+    finding_levels = ["ignore", "style", "info", "warning", "error"]
+    # What level you want to alert on
+    alert_level = os.environ.get("HADOLINT_THRESHOLD", "warning")
+    # Remove alerting up to the level you want to alert at
+    alert_levels = finding_levels[finding_levels.index(alert_level) :]
+
+    with open(file_location) as findings:
+        findings = json.load(findings)
+        package_name = f"Dockerfile: {os.getenv('DOCKERFILE')}"
+        scan_results = {
+            # Hadolint only scans Dockerfiles, so it is the only source
+            package_name: [],
+        }
+        for result in findings:
+            # Only set findings based on if it is in the alerting levels
+            if result["level"] in alert_levels:
+                issue = {
+                    "id": result["code"],
+                    "severity": result["level"],
+                    # The status is not compliant to the hadolint scan
+                    "status": "Not compliant",
+                    "cause": f"Line location: {result['line']}",
+                    "description": result["message"],
+                }
+                scan_results[package_name].append(issue)
+        # If we don't have any findings, we want to return an empty dict
+        if not scan_results[package_name]:
+            return {}
+    return scan_results
+
+
+if __name__ == "__main__":
+    image_findings = {
+        "Trivy": parse_trivy(),
+        "Anchore": parse_anchore(),
+        "Hadolint": parse_hadolint(),
+    }
+
+    with open("parsed_results.json", "w") as output:
+        json.dump(image_findings, output)
+
+    # Creates markdown files for the results. The github markdown file is created by default 
+    # for displaying the workflow summary. If there are other formats defined in the environment variable FINDINGS_FORMAT, 
+    # then it will create them as well
+    create_github_markdown(image_findings, "github_markdown.md")
+
+    markdown_format = os.environ.get("FINDINGS_FORMAT", "github_markdown").lower()
+    if markdown_format == "github_markdown":
+        create_github_markdown(image_findings, "markdown.md")
+    # elif markdown_format != "some_other_format":
+    #     run_that_function_here(image_findings)

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,5 @@
+# Trivy configuration file
+
+# The trivy action doesn't let us use the yaml version of the ignore file. The YAML version
+# has more features, such as path ignore, expiring ignores, etc
+ignorefile: .trivyignore.yaml


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Created python scripts to parse JSON files from scanners, and create markdown for easier viewing of results
- Created new workflows for the new image scanning logic
- Create action for image scan

## Context for reviewers

I put things in parallel to the existing workflows so I can test if these changes work, without messing with any subsequent runs. I had to tweak the files from the contract's version since it has things more specific to our setup and aren't needed here.

The main changes here will make all image scans save findings to JSON, and then a python script to parse and format it into a clean markdown file that we can view in the workflow summary, and use for creating Github tickets. The ticket creation and Slack alerting is disabled by default, with comments on what it takes to enable. 

There's some side benefits of this, such as handling if the image is ARM based, and better trivy finding ignore functionality. There is a change to the current method of parallel scanning, to being a single build and use that image on all of the scanners. This is because as images grow, the time it takes to build also increase, and it doesn't make a lot of sense to build it multiple times (IMHO). In real life, the CI unit and coverage tests takes the same time, or longer than this change

## Testing

Testing will be handled by the PR running these workflows

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-169-app-dev-1653289684.us-east-1.elb.amazonaws.com
- Deployed commit: d8f4fbe8c5a9ee984581f04a58bef7ea99ac6559
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: http://p-169-app-rails-dev-663016209.us-east-1.elb.amazonaws.com
- Deployed commit: d8f4fbe8c5a9ee984581f04a58bef7ea99ac6559
<!-- app-rails - end PR environment info -->