### PR TITLE
Support ephemeral write mounts for services

### DIFF
--- a/app-rails/Dockerfile
+++ b/app-rails/Dockerfile
@@ -20,6 +20,8 @@ ENV RAILS_ENV="production" \
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3100
 
+# In production, this should be the only filesystem location with writes
+VOLUME /rails/tmp
 
 ##########################################################################################
 # BUILD: Throw-away build stage
@@ -73,6 +75,10 @@ RUN gem install debug -v 1.10.0
 
 # Copy application code
 COPY . .
+
+# During local development, app is configured to write to more places
+VOLUME /rails/log
+VOLUME /rails/storage
 
 CMD ["./bin/dev"]
 

--- a/app-rails/docker-compose.mock-production.yml
+++ b/app-rails/docker-compose.mock-production.yml
@@ -15,6 +15,7 @@ services:
   # Rails app
   # Configured for "production" RAILS_ENV
   app-rails:
+    read_only: true
     build:
       context: .
       target: release

--- a/infra/app-rails/app-config/env-config/outputs.tf
+++ b/infra/app-rails/app-config/env-config/outputs.tf
@@ -41,6 +41,10 @@ output "service_config" {
       # For job configs that don't define a source_bucket, add the source_bucket config property
       job_name => merge({ source_bucket = local.bucket_name }, job_config)
     }
+
+    ephemeral_write_volumes = [
+      "/rails/tmp"
+    ]
   }
 }
 

--- a/infra/app-rails/service/main.tf
+++ b/infra/app-rails/service/main.tf
@@ -125,9 +125,7 @@ module "service" {
     } : {},
   )
 
-  ephemeral_write_volumes = [
-    "/rails/tmp"
-  ]
+  ephemeral_write_volumes = local.service_config.ephemeral_write_volumes
 
   is_temporary = local.is_temporary
 

--- a/infra/app-rails/service/main.tf
+++ b/infra/app-rails/service/main.tf
@@ -125,6 +125,10 @@ module "service" {
     } : {},
   )
 
+  ephemeral_write_volumes = [
+    "/rails/tmp"
+  ]
+
   is_temporary = local.is_temporary
 
   # Template Divergent Variables

--- a/infra/app-rails/service/main.tf
+++ b/infra/app-rails/service/main.tf
@@ -128,6 +128,6 @@ module "service" {
   is_temporary = local.is_temporary
 
   # Template Divergent Variables
-  container_read_only = false
+  container_read_only = true
   healthcheck_type    = "curl"
 }

--- a/infra/app-rails/service/main.tf
+++ b/infra/app-rails/service/main.tf
@@ -132,6 +132,5 @@ module "service" {
   is_temporary = local.is_temporary
 
   # Template Divergent Variables
-  container_read_only = true
-  healthcheck_type    = "curl"
+  healthcheck_type = "curl"
 }

--- a/infra/app/app-config/env-config/outputs.tf
+++ b/infra/app/app-config/env-config/outputs.tf
@@ -41,6 +41,8 @@ output "service_config" {
       # For job configs that don't define a source_bucket, add the source_bucket config property
       job_name => merge({ source_bucket = local.bucket_name }, job_config)
     }
+
+    ephemeral_write_volumes = []
   }
 }
 

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -125,5 +125,7 @@ module "service" {
     } : {},
   )
 
+  ephemeral_write_volumes = local.service_config.ephemeral_write_volumes
+
   is_temporary = local.is_temporary
 }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -90,7 +90,7 @@ resource "aws_ecs_task_definition" "app" {
       cpu                    = var.cpu,
       networkMode            = "awsvpc",
       essential              = true,
-      readonlyRootFilesystem = var.container_read_only && !var.enable_command_execution,
+      readonlyRootFilesystem = !var.enable_command_execution,
 
       # Need to define all parameters in the healthCheck block even if we want
       # to use AWS's defaults, otherwise the terraform plan will show a diff

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -31,6 +31,19 @@ locals {
       { name : name, value : value }
     ],
   )
+
+  ephemeral_write_volumes_with_name = [for container_path in var.ephemeral_write_volumes : {
+    container_path : container_path,
+    volume_name : replace(trim(container_path, "/"), "/", "_"),
+  }]
+  ephemeral_write_volumes = [for e in local.ephemeral_write_volumes_with_name : {
+    mount_point : {
+      "sourceVolume" : e.volume_name
+      "containerPath" : e.container_path,
+      "readOnly" : false
+    },
+    volume : { "name" : e.volume_name }
+  }]
 }
 
 #-------------------
@@ -113,12 +126,19 @@ resource "aws_ecs_task_definition" "app" {
           "awslogs-region"        = data.aws_region.current.name,
           "awslogs-stream-prefix" = local.log_stream_prefix
         }
-      }
-      mountPoints    = []
+      },
+      mountPoints    = [for e in local.ephemeral_write_volumes : e.mount_point]
       systemControls = []
       volumesFrom    = []
     }
   ])
+
+  dynamic "volume" {
+    for_each = [for e in local.ephemeral_write_volumes : e.volume]
+    content {
+      name = volume.value["name"]
+    }
+  }
 
   cpu    = var.cpu
   memory = var.memory

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -36,7 +36,7 @@ locals {
     container_path : container_path,
     volume_name : replace(trim(container_path, "/"), "/", "_"),
   }]
-  ephemeral_write_volumes = [for e in local.ephemeral_write_volumes_with_name : {
+  ephemeral_write_volume_configs = [for e in local.ephemeral_write_volumes_with_name : {
     mount_point : {
       "sourceVolume" : e.volume_name
       "containerPath" : e.container_path,
@@ -127,14 +127,14 @@ resource "aws_ecs_task_definition" "app" {
           "awslogs-stream-prefix" = local.log_stream_prefix
         }
       },
-      mountPoints    = [for e in local.ephemeral_write_volumes : e.mount_point]
+      mountPoints    = local.ephemeral_write_volume_configs[*].mount_point
       systemControls = []
       volumesFrom    = []
     }
   ])
 
   dynamic "volume" {
-    for_each = [for e in local.ephemeral_write_volumes : e.volume]
+    for_each = local.ephemeral_write_volume_configs[*].volume
     content {
       name = volume.value["name"]
     }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -170,6 +170,12 @@ variable "vpc_id" {
   description = "Uniquely identifies the VPC."
 }
 
+variable "ephemeral_write_volumes" {
+  type        = set(string)
+  description = "A set of absolute paths in the container to be mounted as writable for the life of the task. These should also be declared with VOLUME statements in the container definition file."
+  default     = []
+}
+
 # Custom Template-diverging variables
 variable "container_read_only" {
   type        = bool

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -172,7 +172,7 @@ variable "vpc_id" {
 
 variable "ephemeral_write_volumes" {
   type        = set(string)
-  description = "A set of absolute paths in the container to be mounted as writable for the life of the task. These should also be declared with VOLUME statements in the container definition file."
+  description = "A set of absolute paths in the container to be mounted as writable for the life of the task. These should also be declared with VOLUME statements in the container build file."
   default     = []
 }
 

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -177,12 +177,6 @@ variable "ephemeral_write_volumes" {
 }
 
 # Custom Template-diverging variables
-variable "container_read_only" {
-  type        = bool
-  description = "Whether the container root filesystem should be read-only"
-  default     = true
-}
-
 variable "healthcheck_type" {
   type        = string
   description = "Whether to configure a curl or wget healthcheck. curl is more common. use wget for alpine-based images"


### PR DESCRIPTION
## Ticket

Related to https://github.com/navapbc/template-application-rails/issues/58

## Changes

Rather than support/encourage a writable root filesystem, support explicitly defining locations that are writable, which is also helpful for development purposes.

## Context for reviewers

- `app-rails/` changes go to `template-application-rails`
- `infra/modules/` changes go to `template-infra`
- Common bits of `infra/app/` and `infra/app-rails/` go to `template-infra`
- `infra/app-rails/` customizations apply to this repo (after previous changes are merged to respective repos, then merged to this one)

## Testing

See CI.

Clicked around PR Env.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-175-app-dev-808286377.us-east-1.elb.amazonaws.com
- Deployed commit: 9410bfd3d9d4cd8d92e4eb5621e1d389e32a0a81
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: http://p-175-app-rails-dev-1338933003.us-east-1.elb.amazonaws.com
- Deployed commit: 9410bfd3d9d4cd8d92e4eb5621e1d389e32a0a81
<!-- app-rails - end PR environment info -->