### PR TITLE
Use service provided healthcheck, with fallbacks

### DIFF
--- a/app-rails/Dockerfile
+++ b/app-rails/Dockerfile
@@ -117,7 +117,6 @@ ENV RAILS_ENV="production" \
 # Install packages needed for deployment
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
-        curl \
         libvips \
         libyaml-dev \
         postgresql-client \

--- a/infra/app-rails/service/main.tf
+++ b/infra/app-rails/service/main.tf
@@ -130,7 +130,4 @@ module "service" {
   ]
 
   is_temporary = local.is_temporary
-
-  # Template Divergent Variables
-  healthcheck_type = "curl"
 }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -100,7 +100,7 @@ resource "aws_ecs_task_definition" "app" {
         retries  = 3,
         timeout  = 5,
         command = ["CMD-SHELL",
-          var.healthcheck_type == "curl" ? "curl --fail http://localhost:${var.container_port}/health || exit 1" : "wget --no-verbose --tries=1 --spider http://localhost:${var.container_port}/health || exit 1"
+          "([ -x \"$(command -v healthcheck)\" ] && healthcheck) || ([ -x \"$(command -v wget)\" ] && wget -q --spider http://127.0.0.1:$PORT/health) || ([ -x \"$(command -v curl)\" ] && curl --fail --silent http://localhost:$PORT/health > /dev/null) || ([ -x \"$(command -v bash)\" ] && bash -c \"exec 3<>/dev/tcp/127.0.0.1/$PORT;echo -e 'GET /health HTTP/1.1\\r\\nHost: http://localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3;grep -q '^HTTP/1.1 200 OK' <&3\") || exit 1"
         ]
       },
       environment = local.environment_variables,

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -175,14 +175,3 @@ variable "ephemeral_write_volumes" {
   description = "A set of absolute paths in the container to be mounted as writable for the life of the task. These should also be declared with VOLUME statements in the container definition file."
   default     = []
 }
-
-# Custom Template-diverging variables
-variable "healthcheck_type" {
-  type        = string
-  description = "Whether to configure a curl or wget healthcheck. curl is more common. use wget for alpine-based images"
-  default     = "wget"
-  validation {
-    condition     = contains(["curl", "wget"], var.healthcheck_type)
-    error_message = "choose either: curl or wget"
-  }
-}


### PR DESCRIPTION
## Changes

Rather than support a limited set of configurable healthcheck options, prefer a defined `healthcheck` executable that the service image provides (since it will best know what healthy is for itself), falling back through some common HTTP options if a `healthcheck` executable is not provided.

Longer term this also better supports folks trimming down their image size.

## Context for reviewers

Helps running `template-application-rails` apps without deviations from upstream `template-infra` .

- May want to choose a more specific name than `healthcheck` for the convention
- Not sure how many fallback options to realistically support, the bash one could be replaced by a similar netcat one if we think that'd cover more bases
- We'll want to document the convention of providing an `healthcheck` executable in `template-infra` docs

Breakdown:
- `app-rails/` changes not strictly required, but would go to `template-application-rails`
- `infra/modules/` changes go to `template-infra`
- `infra/app-rails/` changes apply to this repo (after previous points are merged)

## Testing

See PR Env deploys complete.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-176-app-dev-1227445401.us-east-1.elb.amazonaws.com
- Deployed commit: fed685b5d42315c38b840489d2042a0e4750a937
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: http://p-176-app-rails-dev-1776651285.us-east-1.elb.amazonaws.com
- Deployed commit: fed685b5d42315c38b840489d2042a0e4750a937
<!-- app-rails - end PR environment info -->