### PR TITLE
Add ability to run task commands in PR environment

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -27,6 +27,7 @@ set -euo pipefail
 # Parse optional parameters
 environment_variables=""
 task_role_arn=""
+workspace_name=""
 while :; do
   case "$1" in
     --environment-variables)
@@ -35,6 +36,10 @@ while :; do
       ;;
     --task-role-arn)
       task_role_arn="$2"
+      shift 2
+      ;;
+    --workspace)
+      workspace_name="$2"
       shift 2
       ;;
     *)
@@ -56,7 +61,19 @@ echo "  environment=${environment}"
 echo "  command=${command}"
 echo "  environment_variables=${environment_variables:-}"
 echo "  task_role_arn=${task_role_arn:-}"
+echo "  workspace_name=${workspace_name:-}"
 echo
+
+# Initialize terraform and select workspace if specified
+./bin/terraform-init "infra/${app_name}/service" "${environment}"
+
+if [ -n "${workspace_name}" ]; then
+  # Set up trap to restore workspace on script exit
+  original_workspace=$(terraform -chdir="infra/${app_name}/service" workspace show)
+  trap 'terraform -chdir="infra/${app_name}/service" workspace select "${original_workspace}"' EXIT
+
+  terraform -chdir="infra/${app_name}/service" workspace select "${workspace_name}"
+fi
 
 # Use the same cluster, task definition, and network configuration that the application service uses
 cluster_name=$(terraform -chdir="infra/${app_name}/service" output -raw service_cluster_name)


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/718
Resolves https://github.com/navapbc/template-infra/issues/878

## Changes

- Add optional parameter --workspace <workspace_name> to bin/run-command
- Fix bug where run-command ignored environment parameter and just ran in currently initialized environment

## Context for reviewers

This feature makes it possible to test changes to background jobs in a PR environment by using the run-command script

## Testing

<details><summary>Ran `bin/run-command --workspace p-181 app dev '["python", "-m", "flask", "--app", "app.py", "cron"]'` and looked at the logs in the p-181-app-dev cluster in AWS console</summary>

<details><summary>After running the command, I can see that I am back on the default workspace</summary>
<img width="574" alt="image" src="https://github.com/user-attachments/assets/1f5f89a4-3baf-428d-9fe9-4cc4063d49c6" />
</details>

<details><summary>Ctrl+C in the middle of the script also switches me back to the original workspace</summary>
<img width="579" alt="image" src="https://github.com/user-attachments/assets/4bbf60d7-c5c7-4ff4-b3b6-2a78cdd7b17b" />
</details>

<img width="594" alt="image" src="https://github.com/user-attachments/assets/bcb6374d-96e4-4237-b6c3-3103a5c2b305" />

<img width="528" alt="image" src="https://github.com/user-attachments/assets/8c9af7bb-7f0d-4cc6-a10a-a8cb408ccad3" />

<img width="1607" alt="image" src="https://github.com/user-attachments/assets/129d7bbc-272b-4b73-84d8-583b104cf6a4" />

</details>

<!-- app - begin PR environment info -->
## Preview environment for app
♻️ Environment destroyed ♻️
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
♻️ Environment destroyed ♻️
<!-- app-rails - end PR environment info -->