### PR TITLE
Generate infra service test id from timestamp

### DIFF
--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -16,12 +16,11 @@ import (
 	"time"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-var uniqueId = strings.ToLower(random.UniqueId())
+var uniqueId = strings.ToLower(generateTestId())
 var workspaceName = fmt.Sprintf("t-%s", uniqueId)
 var testAppName = os.Getenv("APP_NAME")
 
@@ -93,4 +92,27 @@ func DestroyService(t *testing.T, terraformOptions *terraform.Options) {
 	fmt.Println("::group::Destroy service layer")
 	terraform.Destroy(t, terraformOptions)
 	fmt.Println("::endgroup::")
+}
+
+func generateTestId() string {
+	now := time.Now()
+	// Combine hour, minute, second, and millisecond into a single number
+	timeNum := int64(now.Hour())*3600000 +
+		int64(now.Minute())*60000 +
+		int64(now.Second())*1000 +
+		int64(now.Nanosecond()/1000000)
+	return toBase62(timeNum)
+}
+
+func toBase62(n int64) string {
+	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	if n == 0 {
+		return "0"
+	}
+	result := ""
+	for n > 0 {
+		result = string(charset[n%62]) + result
+		n /= 62
+	}
+	return result
 }

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -96,11 +96,7 @@ func DestroyService(t *testing.T, terraformOptions *terraform.Options) {
 
 func generateTestId() string {
 	now := time.Now()
-	// Combine hour, minute, second, and millisecond into a single number
-	timeNum := int64(now.Hour())*3600000 +
-		int64(now.Minute())*60000 +
-		int64(now.Second())*1000 +
-		int64(now.Nanosecond()/1000000)
+	timeNum := now.Unix()
 	return toBase62(timeNum)
 }
 

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -107,12 +107,16 @@ func generateTestId() string {
 func toBase62(n int64) string {
 	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	if n == 0 {
-		return "0"
+		return "000000"
 	}
 	result := ""
 	for n > 0 {
 		result = string(charset[n%62]) + result
 		n /= 62
+	}
+	// Pad with leading zeros to ensure at least 6 characters
+	for len(result) < 6 {
+		result = "0" + result
 	}
 	return result
 }


### PR DESCRIPTION
## Ticket

Work towards https://github.com/navapbc/template-infra/issues/787

## Changes

see title

## Context for reviewers

This is the first step towards https://github.com/navapbc/template-infra/issues/787

The ultimate goal is to have a way to look for stale environments generated by the infra service tests. The way we plan on doing that is to encode timestamp information in the id itself, but because we want the id to be short we are base62 encoding the id.

## Testing

I looked at the ci-infra-app-service.yml and ci-infra-app-rails-service.yml workflows and manually decoded the base62 ids, then compared the resulting timestamps to the UTC timestamps that the jobs started on and saw that they roughly matched.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: http://p-182-app-dev-8425939.us-east-1.elb.amazonaws.com
- Deployed commit: a250e576473d7aa7e9240d102a0cab02a181ac83
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: http://p-182-app-rails-dev-1852731477.us-east-1.elb.amazonaws.com
- Deployed commit: a250e576473d7aa7e9240d102a0cab02a181ac83
<!-- app-rails - end PR environment info -->