### PR TITLE
Add deploy failure system notification

### DIFF
--- a/.github/workflows/cd-app.yml
+++ b/.github/workflows/cd-app.yml
@@ -35,3 +35,4 @@ jobs:
       app_name: "app"
       environment: ${{ inputs.environment || 'dev' }}
       version: ${{ inputs.version || 'main' }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,5 +85,5 @@ jobs:
     uses: ./.github/workflows/send-system-notification.yml
     with:
       channel: "workflow-failures"
-      message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}]((https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+      message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,19 @@ jobs:
     # By default, don't run e2e tests on production to avoid generating
     # junk data that may interfere with production metrics and business operations
     if: inputs.environment != 'prod'
-    needs: [deploy]
+    needs: deploy
     uses: ./.github/workflows/e2e-tests.yml
     with:
       app_name: ${{ inputs.app_name }}
       service_endpoint: ${{ needs.deploy.outputs.service_endpoint }}
+
+  notify:
+    name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
+    needs: e2e
+    if: failure()
+    uses: ./.github/workflows/send-system-notification.yml
+    with:
+      channel: "workflow-failures"
+      message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}]((https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
+    secrets: inherit
+    

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,6 @@ jobs:
       service_endpoint: ${{ steps.deploy-release.outputs.service_endpoint }}
 
     steps:
-      - run: exit 1
       - uses: actions/checkout@v4
 
       - name: Set up Terraform
@@ -87,3 +86,4 @@ jobs:
       channel: "workflow-failures"
       message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
     secrets: inherit
+    

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
       service_endpoint: ${{ steps.deploy-release.outputs.service_endpoint }}
 
     steps:
+      - run: exit 1
       - uses: actions/checkout@v4
 
       - name: Set up Terraform
@@ -86,4 +87,3 @@ jobs:
       channel: "workflow-failures"
       message: "❌ [Failed deploying ${{ inputs.version }} to ${{ inputs.app_name }} ${{ inputs.environment }}]((https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))"
     secrets: inherit
-    


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

see title

## Context for reviewers

Seems useful to send a slack notification when a deploy fails rather than relying on the email which only goes to the engineer that merged a PR

## Testing

Introduce a forced failure in https://github.com/navapbc/platform-test/pull/195/commits/05cda7d669e924f09cba97933dd9b821785b3886 then run cd-app.yml workflow from this branch
([see workflow run](https://github.com/navapbc/platform-test/actions/runs/14094790932))

This is what the notification looks like
<img width="442" alt="image" src="https://github.com/user-attachments/assets/195cf044-d165-4559-8d33-5f1e42528c84" />
🔒 [link to notification](https://nava.slack.com/archives/C03G1SWD9H7/p1743028680892069)

Remove forced failure and rerun to show that deploys still work: [see workflow run](https://github.com/navapbc/platform-test/actions/runs/14094937597)


<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-195-app-dev-665886569.us-east-1.elb.amazonaws.com
- Deployed commit: c67019a1f309a88b1dc2060d4549014ed7fbca08
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: https://p-195-app-rails-dev-1333915753.us-east-1.elb.amazonaws.com
- Deployed commit: c67019a1f309a88b1dc2060d4549014ed7fbca08
<!-- app-rails - end PR environment info -->