### PR TITLE
[draft] Update CI vulnerability workflow to reduce how often the docker image is built

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -85,12 +85,6 @@ jobs:
           --cache-from=type=local,src=/tmp/.buildx-cache \
           --cache-to=type=local,dest=/tmp/.buildx-cache"
 
-      - name: Check disk space, including docker usage
-        if: success() || failure()
-        run: |
-          df -h
-          docker system df
-
       - name: Save Docker image
         if: steps.cache-buildx.outputs.cache-hit != 'true'
         run: |
@@ -102,12 +96,6 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
-
-      - name: Check disk space, including docker usage
-        if: success() || failure()
-        run: |
-          df -h
-          docker system df
 
   trivy-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -112,6 +112,7 @@ jobs:
 
   trivy-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -128,19 +129,23 @@ jobs:
         with:
           files: ${{ inputs.app_name }}/trivy-secret.yaml trivy-secret.yaml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
-          image-ref: ${{ steps.build-image.outputs.image }}
+          image-ref: ${{ needs.build-and-cache.outputs.image }}
           format: table
           exit-code: 1
           ignore-unfixed: true

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -200,6 +200,7 @@ jobs:
 
   dockle-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -211,13 +212,17 @@ jobs:
             ${{ inputs.app_name }}/.dockleconfig
             .dockleconfig
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable, this will save the variable in this file to env for Dockle
@@ -230,7 +235,7 @@ jobs:
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.3.1
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.build-and-cache.outputs.image }}
           exit-code: "1"
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -162,6 +162,7 @@ jobs:
 
   anchore-scan:
     runs-on: ubuntu-latest
+    needs: build-and-cache
 
     steps:
       - uses: actions/checkout@v4
@@ -173,18 +174,22 @@ jobs:
             ${{ inputs.app_name }}/.grype.yml
             .grype.yml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-docker-image-
+
+      - name: Load cached Docker image
         run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          docker load < /tmp/docker-image.tar
 
       - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v3
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.build-and-cache.outputs.image }}
           output-format: table
         env:
           GRYPE_CONFIG: ${{ steps.grype-config.outputs.found_file }}

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -79,7 +79,6 @@ jobs:
         # If there's an exact match in cache, skip build entirely
         if: steps.cache-buildx.outputs.cache-hit != 'true'
         run: |
-          docker buildx du --verbose
           make release-build \
           APP_NAME=${{ inputs.app_name }} \
           OPTIONAL_BUILD_FLAGS=" \

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -1,8 +1,9 @@
-# GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
-# to ensure images built are secure before they are deployed.
+# GitHub Actions CI workflow that runs vulnerability scans on the application's 
+# Dockerfile or Docker image to ensure images built are secure before they are deployed.
 
-# NOTE: The workflow isn't able to pass the docker image between jobs, so each builds the image.
-#       A future PR will pass the image between the scans to reduce overhead and increase speed
+# The docker image is built once and cached, with that image used by the jobs that 
+# require access to the image. 
+
 name: Vulnerability Scans
 
 on:
@@ -40,6 +41,74 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: cat hadolint-results.txt >> "$GITHUB_STEP_SUMMARY"
+
+  build-and-cache:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.shared-output.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          driver: docker
+
+      - name: Cache Docker layers
+        id: cache-buildx
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ inputs.app_name }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ inputs.app_name }}-buildx-
+
+      - name: Ensure Buildx cache exists
+        run: |
+          mkdir -p /tmp/.buildx-cache
+
+      - name: Set shared outputs
+        id: shared-output
+        run: |
+          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
+          IMAGE_TAG=$(make release-image-tag)
+          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and tag Docker image for scanning
+        # If there's an exact match in cache, skip build entirely
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          docker buildx du --verbose
+          make release-build \
+          APP_NAME=${{ inputs.app_name }} \
+          OPTIONAL_BUILD_FLAGS=" \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache"
+
+      - name: Check disk space, including docker usage
+        if: success() || failure()
+        run: |
+          df -h
+          docker system df
+
+      - name: Save Docker image
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          docker save ${{ steps.shared-output.outputs.image }} > /tmp/docker-image.tar
+
+      - name: Cache Docker image
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: ${{ inputs.app_name }}-docker-image-${{ github.sha }}
+
+      - name: Check disk space, including docker usage
+        if: success() || failure()
+        run: |
+          df -h
+          docker system df
 
   trivy-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

Refactors docker image creation in the `vulnerability-scans.yml` workflow:
- new job: `build-and-cache`: builds the image and puts it in a cache
- updates other jobs to use the cached image, instead of building the image as part of the job

## Context for reviewers

Based off of the implementation in HHS/simpler-grants-gov:  https://github.com/HHS/simpler-grants-gov/blob/6dadc31f8474c386b824654d3ce2bb428bec584f/.github/workflows/vulnerability-scans.yml 

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
