### PR TITLE
Dry up spam tests into single spec

### DIFF
--- a/app-rails/app/controllers/users/passwords_controller.rb
+++ b/app-rails/app/controllers/users/passwords_controller.rb
@@ -3,6 +3,18 @@
 class Users::PasswordsController < ApplicationController
   skip_after_action :verify_authorized
 
+  def auth_service
+    self.class.auth_service || AuthService.new
+  end
+
+  def self.auth_service
+    @auth_service
+  end
+
+  def self.auth_service=(service)
+    @auth_service = service
+  end
+
   def forgot
     @form = Users::ForgotPasswordForm.new
   end

--- a/app-rails/app/controllers/users/registrations_controller.rb
+++ b/app-rails/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,18 @@ class Users::RegistrationsController < ApplicationController
   layout "users"
   skip_after_action :verify_authorized
 
+  def auth_service
+    self.class.auth_service || AuthService.new
+  end
+
+  def self.auth_service
+    @auth_service
+  end
+
+  def self.auth_service=(service)
+    @auth_service = service
+  end
+
   def new
     @form = Users::RegistrationForm.new()
     render :new

--- a/app-rails/app/controllers/users/sessions_controller.rb
+++ b/app-rails/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,18 @@ class Users::SessionsController < Devise::SessionsController
   layout "users"
   skip_after_action :verify_authorized
 
+  def auth_service
+    self.class.auth_service || AuthService.new
+  end
+
+  def self.auth_service
+    @auth_service
+  end
+
+  def self.auth_service=(service)
+    @auth_service = service
+  end
+
   def new
     @form = Users::NewSessionForm.new
   end

--- a/app-rails/app/services/auth_service.rb
+++ b/app-rails/app/services/auth_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class AuthService
-  def initialize(auth_adapter = Auth::CognitoAdapter.new)
-    @auth_adapter = auth_adapter
+  def initialize(auth_adapter = nil)
+    @auth_adapter = auth_adapter || default_adapter
   end
 
   # Send a confirmation code that's required to change the user's password
@@ -71,6 +71,14 @@ class AuthService
   end
 
   private
+
+  def default_adapter
+    if Rails.application.config.respond_to?(:auth_adapter_class)
+      Rails.application.config.auth_adapter_class.constantize.new
+    else
+      Auth::CognitoAdapter.new
+    end
+  end
 
     def create_db_user(uid, email, provider)
       Rails.logger.info "Creating User uid: #{uid}"

--- a/app-rails/config/environments/test.rb
+++ b/app-rails/config/environments/test.rb
@@ -8,6 +8,8 @@ require "active_support/core_ext/integer/time"
 # Custom setting: set the default url.
 Rails.application.default_url_options[:host] = "localhost"
 
+Rails.application.config.auth_adapter_class = "Auth::MockAdapter"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/app-rails/db/schema.rb
+++ b/app-rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_10_140243) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_14_194640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_10_140243) do
     t.integer "mfa_preference"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "encrypted_password"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 

--- a/app-rails/spec/controllers/users/passwords_controller_spec.rb
+++ b/app-rails/spec/controllers/users/passwords_controller_spec.rb
@@ -44,15 +44,6 @@ RSpec.describe Users::PasswordsController do
 
       expect(response.status).to eq(422)
     end
-
-    it "handles submission by bots" do
-      post :send_reset_password_instructions, params: {
-        users_forgot_password_form: { email: "UsernameExists@example.com", spam_trap: "I am a bot" },
-        locale: "en"
-      }
-
-      expect(response.status).to eq(422)
-    end
   end
 
   describe "GET reset" do
@@ -98,20 +89,6 @@ RSpec.describe Users::PasswordsController do
           email: "test@example.com",
           code: "000001",
           password: "password"
-        },
-        locale: "en"
-      }
-
-      expect(response.status).to eq(422)
-    end
-
-    it "handles submission by bots" do
-      post :confirm_reset, params: {
-        users_reset_password_form: {
-          email: "test@example.com",
-          code: "123456",
-          password: "password",
-          spam_trap: "I am a bot"
         },
         locale: "en"
       }

--- a/app-rails/spec/controllers/users/registrations_controller_spec.rb
+++ b/app-rails/spec/controllers/users/registrations_controller_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Users::RegistrationsController do
 
       expect(response.status).to eq(422)
     end
-
   end
 
   describe "GET new_account_verification" do

--- a/app-rails/spec/controllers/users/registrations_controller_spec.rb
+++ b/app-rails/spec/controllers/users/registrations_controller_spec.rb
@@ -58,21 +58,6 @@ RSpec.describe Users::RegistrationsController do
       expect(response.status).to eq(422)
     end
 
-    it "handles submission by bots" do
-      email = "test@example.com"
-
-      post :create, params: {
-        users_registration_form: {
-          email: email,
-          password: "password",
-
-          spam_trap: "I am a bot"
-        },
-        locale: "en"
-      }
-
-      expect(response.status).to eq(422)
-    end
   end
 
   describe "GET new_account_verification" do

--- a/app-rails/spec/controllers/users/sessions_controller_spec.rb
+++ b/app-rails/spec/controllers/users/sessions_controller_spec.rb
@@ -94,20 +94,6 @@ RSpec.describe Users::SessionsController do
       expect(response).to redirect_to(session_challenge_path)
     end
 
-    it "handles submission by bots" do
-      create(:user, uid: uid)
-
-      post :create, params: {
-        users_new_session_form: {
-          email: "test@example.com",
-          password: "password",
-          spam_trap: "I am a bot"
-        },
-        locale: "en"
-      }
-
-      expect(response.status).to eq(422)
-    end
   end
 
   describe "GET challenge" do

--- a/app-rails/spec/controllers/users/sessions_controller_spec.rb
+++ b/app-rails/spec/controllers/users/sessions_controller_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Users::SessionsController do
       expect(session[:challenge_email]).to eq("mfa@example.com")
       expect(response).to redirect_to(session_challenge_path)
     end
-
   end
 
   describe "GET challenge" do

--- a/app-rails/spec/requests/spam_traps_spec.rb
+++ b/app-rails/spec/requests/spam_traps_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "Spam trap protection for public forms", type: :request do
         email: "evenneweruser@example.com",
         password: "aLongPassword123"
       }
+    },
+    {
+      name: "Login",
+      path: "/users/sign_in",
+      param_key: :users_new_session_form,
+      valid_params: {
+        email: "test@example.com",
+        password: "password"
+      }
     }
   ]
 
@@ -52,10 +61,6 @@ RSpec.describe "Spam trap protection for public forms", type: :request do
       it "rejects spam submissions" do
         post form[:path], params: spam_params
         expect(response).to have_http_status(422), "Expected 422 for #{form[:name]} form, but got #{response.status}"
-      end
-      it "allows valid submissions" do
-        post form[:path], params: valid_params
-        expect(response).to have_http_status(302), "Expected redirect for valid #{form[:name]} form, but got #{response.status}"
       end
     end
   end

--- a/app-rails/spec/requests/spam_traps_spec.rb
+++ b/app-rails/spec/requests/spam_traps_spec.rb
@@ -1,67 +1,73 @@
-RSpec.describe "Spam trap protection for public forms", type: :request do
-  before do
-    allow_any_instance_of(Users::PasswordsController).to receive(:auth_service).and_return(
-      AuthService.new(Auth::MockAdapter.new)
-    )
-  end
 
-  forms = [
-    {
-      name: "Password reset instructions",
-      path: "/users/forgot-password",
-      param_key: :users_forgot_password_form,
-      valid_params: {
-        email: "UsernameDoesntExistForSure@example.com"
-      }
-    },
-    {
-      name: "Password confirm reset",
-      path: "/users/reset-password",
-      param_key: :users_reset_password_form,
-      valid_params: {
-        email: "testIsANewUser@example.com",
-        code: "123456",
-        password: "aLongPassword123"
-      }
-    },
-    {
-      name: "Registration",
-      path: "/users/registrations",
-      param_key: :users_registration_form,
-      valid_params: {
-        email: "evenneweruser@example.com",
-        password: "aLongPassword123"
-      }
-    },
-    {
-      name: "Login",
-      path: "/users/sign_in",
-      param_key: :users_new_session_form,
-      valid_params: {
-        email: "test@example.com",
-        password: "password"
-      }
-    }
-  ]
 
-  forms.each do |form|
-    describe "#{form[:name]} form" do
-      let(:spam_params) do
-        {
-          form[:param_key] => form[:valid_params].merge(spam_trap: "I am a bot")
+
+
+
+  RSpec.describe "Spam trap protection for public forms", type: :request do
+    before do
+      Users::PasswordsController.auth_service = AuthService.new(Auth::MockAdapter.new)
+      Users::RegistrationsController.auth_service = AuthService.new(Auth::MockAdapter.new)
+      Users::SessionsController.auth_service = AuthService.new(Auth::MockAdapter.new(uid_generator: -> { "mock-uid" }))
+    end
+
+    after do
+      # Clean up so this doesn't leak across tests
+      Users::PasswordsController.auth_service = nil
+      Users::RegistrationsController.auth_service = nil
+      Users::SessionsController.auth_service = nil
+    end
+
+    forms = [
+      {
+        name: "Password reset instructions",
+        path: "/users/forgot-password",
+        param_key: :users_forgot_password_form,
+        valid_params: {
+          email: "UsernameDoesntExistForSure@example.com"
         }
-      end
-
-      let(:valid_params) do
-        {
-          form[:param_key] => form[:valid_params]
+      },
+      {
+        name: "Password confirm reset",
+        path: "/users/reset-password",
+        param_key: :users_reset_password_form,
+        valid_params: {
+          email: "testIsANewUser@example.com",
+          code: "123456",
+          password: "aLongPassword123"
         }
-      end
+      },
+      {
+        name: "Registration",
+        path: "/users/registrations",
+        param_key: :users_registration_form,
+        valid_params: {
+          email: "evenneweruser@example.com",
+          password: "aLongPassword123"
+        }
+      },
+      {
+        name: "Login",
+        path: "/users/sign_in",
+        param_key: :users_new_session_form,
+        valid_params: {
+          email: "test@example.com",
+          password: "password"
+        }
+      }
+    ]
 
-      it "rejects spam submissions" do
-        post form[:path], params: spam_params
-        expect(response).to have_http_status(422), "Expected 422 for #{form[:name]} form, but got #{response.status}"
+    forms.each do |form|
+      describe "#{form[:name]} form" do
+        let(:spam_params) do
+          {
+            form[:param_key] => form[:valid_params].merge(spam_trap: "I am a bot")
+          }
+        end
+
+        it "rejects spam submissions" do
+          post form[:path], params: spam_params
+          expect(response).to have_http_status(422), "Expected 422 for #{form[:name]} form, but got #{response.status}"
+        end
       end
     end
   end
-end

--- a/app-rails/spec/requests/spam_traps_spec.rb
+++ b/app-rails/spec/requests/spam_traps_spec.rb
@@ -1,12 +1,9 @@
 RSpec.describe "Spam trap protection for public forms", type: :request do
   before do
-
     allow_any_instance_of(Users::PasswordsController).to receive(:auth_service).and_return(
       AuthService.new(Auth::MockAdapter.new)
     )
-    
   end
-
 
   forms = [
     {
@@ -56,11 +53,8 @@ RSpec.describe "Spam trap protection for public forms", type: :request do
         post form[:path], params: spam_params
         expect(response).to have_http_status(422), "Expected 422 for #{form[:name]} form, but got #{response.status}"
       end
-
       it "allows valid submissions" do
         post form[:path], params: valid_params
-        puts response.body
-        puts "#########"
         expect(response).to have_http_status(302), "Expected redirect for valid #{form[:name]} form, but got #{response.status}"
       end
     end

--- a/app-rails/spec/requests/spam_traps_spec.rb
+++ b/app-rails/spec/requests/spam_traps_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe "Spam trap protection for public forms", type: :request do
+  before do
+
+    allow_any_instance_of(Users::PasswordsController).to receive(:auth_service).and_return(
+      AuthService.new(Auth::MockAdapter.new)
+    )
+    
+  end
+
+
+  forms = [
+    {
+      name: "Password reset instructions",
+      path: "/users/forgot-password",
+      param_key: :users_forgot_password_form,
+      valid_params: {
+        email: "UsernameDoesntExistForSure@example.com"
+      }
+    },
+    {
+      name: "Password confirm reset",
+      path: "/users/reset-password",
+      param_key: :users_reset_password_form,
+      valid_params: {
+        email: "testIsANewUser@example.com",
+        code: "123456",
+        password: "aLongPassword123"
+      }
+    },
+    {
+      name: "Registration",
+      path: "/users/registrations",
+      param_key: :users_registration_form,
+      valid_params: {
+        email: "evenneweruser@example.com",
+        password: "aLongPassword123"
+      }
+    }
+  ]
+
+  forms.each do |form|
+    describe "#{form[:name]} form" do
+      let(:spam_params) do
+        {
+          form[:param_key] => form[:valid_params].merge(spam_trap: "I am a bot")
+        }
+      end
+
+      let(:valid_params) do
+        {
+          form[:param_key] => form[:valid_params]
+        }
+      end
+
+      it "rejects spam submissions" do
+        post form[:path], params: spam_params
+        expect(response).to have_http_status(422), "Expected 422 for #{form[:name]} form, but got #{response.status}"
+      end
+
+      it "allows valid submissions" do
+        post form[:path], params: valid_params
+        puts response.body
+        puts "#########"
+        expect(response).to have_http_status(302), "Expected redirect for valid #{form[:name]} form, but got #{response.status}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

Adresses https://github.com/navapbc/template-application-rails/issues/53

## Changes

> Moved spambot tests into a single test

## Context for reviewers

> This ended up much simpler than was originally envisioned. I'll add this context to the original ticket and leave it open, as it seems I did not end up meeting its expectations:
<img width="1054" alt="Screenshot 2025-04-23 at 3 14 45 PM" src="https://github.com/user-attachments/assets/84e56391-a5d0-405d-b410-0fcb05017729" />


## Testing

> Tests passed.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-199-app-dev-196855303.us-east-1.elb.amazonaws.com
- Deployed commit: 965a77e45d9c4467f0ef3aa03676441f5185d192
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: https://p-199-app-rails-dev-2095149867.us-east-1.elb.amazonaws.com
- Deployed commit: 965a77e45d9c4467f0ef3aa03676441f5185d192
<!-- app-rails - end PR environment info -->