### PR TITLE
removed sassc gem; everything should now be working from dart-sass

### DIFF
--- a/app-rails/Gemfile
+++ b/app-rails/Gemfile
@@ -89,7 +89,7 @@ group :development do
   gem "rubocop-rspec", require: false
 
   # Sass compiling
-  gem "sassc", "~> 2.4"
+
 
   # Test notifications locally without sending the emails
   gem "letter_opener"

--- a/app-rails/Gemfile
+++ b/app-rails/Gemfile
@@ -88,9 +88,6 @@ group :development do
   gem "rubocop-rails-omakase", require: false
   gem "rubocop-rspec", require: false
 
-  # Sass compiling
-
-
   # Test notifications locally without sending the emails
   gem "letter_opener"
 

--- a/app-rails/Gemfile.lock
+++ b/app-rails/Gemfile.lock
@@ -161,16 +161,6 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.1-aarch64-linux-gnu)
-    ffi (1.17.1-aarch64-linux-musl)
-    ffi (1.17.1-arm-linux-gnu)
-    ffi (1.17.1-arm-linux-musl)
-    ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86-linux-gnu)
-    ffi (1.17.1-x86-linux-musl)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
-    ffi (1.17.1-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -382,8 +372,6 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     securerandom (0.4.1)
     selenium-webdriver (4.29.1)
       base64 (~> 0.2)
@@ -481,7 +469,6 @@ DEPENDENCIES
   rspec-rails (~> 6.1.0)
   rubocop-rails-omakase
   rubocop-rspec
-  sassc (~> 2.4)
   selenium-webdriver
   simplecov
   sprockets-rails


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-application-rails/issues/87

## Changes

> the sassc gem was removed.

## Context for reviewers

> We needed to remove the deprecated sassc gem, in favor of dart-sass. It appeared dart-sass was already in play and nothing else needed to change.

## Testing

> I logged into the app and clicked around with an eye out for css issues; none were apparent. 
<img width="1489" alt="Screenshot 2025-04-23 at 2 59 46 PM" src="https://github.com/user-attachments/assets/c38e3e1e-3ccc-432c-9de6-7d92b1bda20c" />


<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-200-app-dev-111417674.us-east-1.elb.amazonaws.com
- Deployed commit: 5770df1f88f7fbe136d30becac8cfc421db99756
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: https://p-200-app-rails-dev-1935337327.us-east-1.elb.amazonaws.com
- Deployed commit: 5770df1f88f7fbe136d30becac8cfc421db99756
<!-- app-rails - end PR environment info -->