### PR TITLE
Fix PR environment destroy race condition

### DIFF
--- a/.github/workflows/pr-environment-checks.yml
+++ b/.github/workflows/pr-environment-checks.yml
@@ -15,6 +15,9 @@ on:
       commit_hash:
         required: true
         type: string
+
+concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
+
 jobs:
   build-and-publish:
     name: " " # GitHub UI is noisy when calling reusable workflows, so use whitespace for name to reduce noise
@@ -33,8 +36,6 @@ jobs:
       id-token: write
       pull-requests: write # Needed to comment on PR
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
-
-    concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
 
     outputs:
       service_endpoint: ${{ steps.update-environment.outputs.service_endpoint }}

--- a/.github/workflows/pr-environment-destroy.yml
+++ b/.github/workflows/pr-environment-destroy.yml
@@ -12,6 +12,9 @@ on:
       pr_number:
         required: true
         type: string
+
+concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
+
 jobs:
   destroy:
     name: Destroy environment
@@ -22,8 +25,6 @@ jobs:
       id-token: write
       pull-requests: write # Needed to comment on PR
       repository-projects: read # Workaround for GitHub CLI bug https://github.com/cli/cli/issues/6274
-
-    concurrency: pr-environment-${{ inputs.app_name }}-${{ inputs.pr_number }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/937

## Changes

see title 

## Context for reviewers

I noticed that occasionally the PR environment gets destroyed (successfully) before it gets created again. Looking into it, it looks like if the PR is closed or merged before the PR environment check's build-and-publish job is completed, the PR environment destroy job will actually run first. This change fixes that issue by moving the concurrency key to operate at the workflow level rather than just at on the job level.

Or more precisely:
1. Dev pushes some final changes to PR before merge
2. PR env update triggers, starts building container to deploy
3. Dev merges PR
4. PR env delete triggers
5. PR env update finishes building, hits concurrency lock on doing the deploy
6. PR env delete completes
7. PR env update is unblocked and deploys updated code, which actually recreates the entire env

## Testing

Ran PR environment destroy soon after PR environment checks started running, and made sure PR environment was actually destroyed

<img width="569" alt="image" src="https://github.com/user-attachments/assets/091d578c-3495-46a7-ad5e-40bc663ca393" />

<img width="1319" alt="image" src="https://github.com/user-attachments/assets/169d5d6c-4992-4b21-a536-02d5450210b6" />

<img width="301" alt="image" src="https://github.com/user-attachments/assets/2b73fb85-38fd-406c-ad12-0ce4d932b70e" />

---

<!-- app - begin PR environment info -->
## Preview environment for app
♻️ Environment destroyed ♻️
<!-- app - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
- Service endpoint: https://p-208-app-rails-dev-555674829.us-east-1.elb.amazonaws.com
- Deployed commit: cf508e7b7ddd4e04667d1dfbaa141262b1dfb40f
<!-- app-rails - end PR environment info -->