### PR TITLE
Replace current-region script with aws configure get region

### DIFF
--- a/bin/current-region
+++ b/bin/current-region
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Print the current AWS region
-set -euo pipefail
-echo -n "$(aws configure list | grep region | awk '{print $2}')"

--- a/bin/is-image-published
+++ b/bin/is-image-published
@@ -14,7 +14,7 @@ image_tag=$(git rev-parse "${git_ref}")
 terraform -chdir="infra/${app_name}/app-config" init > /dev/null
 terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
 image_repository_name="$(terraform -chdir="infra/${app_name}/app-config" output -json build_repository_config | jq -r ".name")"
-region=$(./aws configure get region)
+region=$(aws configure get region)
 
 result=""
 result=$(aws ecr describe-images --repository-name "${image_repository_name}" --image-ids "imageTag=${image_tag}" --region "${region}" 2> /dev/null ) || true

--- a/bin/is-image-published
+++ b/bin/is-image-published
@@ -14,7 +14,7 @@ image_tag=$(git rev-parse "${git_ref}")
 terraform -chdir="infra/${app_name}/app-config" init > /dev/null
 terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
 image_repository_name="$(terraform -chdir="infra/${app_name}/app-config" output -json build_repository_config | jq -r ".name")"
-region=$(./bin/current-region)
+region=$(./aws configure get region)
 
 result=""
 result=$(aws ecr describe-images --repository-name "${image_repository_name}" --image-ids "imageTag=${image_tag}" --region "${region}" 2> /dev/null ) || true

--- a/bin/publish-release
+++ b/bin/publish-release
@@ -19,7 +19,7 @@ terraform -chdir="infra/${app_name}/app-config" init > /dev/null
 terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
 image_repository_name="$(terraform -chdir="infra/${app_name}/app-config" output -json build_repository_config | jq -r ".name")"
 
-region=$(./aws configure get region)
+region=$(aws configure get region)
 read -r image_registry_id image_repository_url <<< "$(aws ecr describe-repositories --repository-names "${image_repository_name}" --query "repositories[0].[registryId,repositoryUri]" --output text)"
 image_registry="${image_registry_id}.dkr.ecr.${region}.amazonaws.com"
 

--- a/bin/publish-release
+++ b/bin/publish-release
@@ -19,7 +19,7 @@ terraform -chdir="infra/${app_name}/app-config" init > /dev/null
 terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
 image_repository_name="$(terraform -chdir="infra/${app_name}/app-config" output -json build_repository_config | jq -r ".name")"
 
-region=$(./bin/current-region)
+region=$(./aws configure get region)
 read -r image_registry_id image_repository_url <<< "$(aws ecr describe-repositories --repository-names "${image_repository_name}" --query "repositories[0].[registryId,repositoryUri]" --output text)"
 image_registry="${image_registry_id}.dkr.ecr.${region}.amazonaws.com"
 

--- a/bin/run-command
+++ b/bin/run-command
@@ -90,7 +90,7 @@ service_task_definition_arn=$(aws ecs describe-services --no-cli-pager --cluster
 task_definition_family=$(aws ecs describe-task-definition --no-cli-pager --task-definition "${service_task_definition_arn}" --query "taskDefinition.family" --output text)
 
 network_config=$(aws ecs describe-services --no-cli-pager --cluster "${cluster_name}" --services "${service_name}" --query "services[0].networkConfiguration")
-current_region=$(./bin/current-region)
+current_region=$(./aws configure get region)
 aws_user_id=$(aws sts get-caller-identity --no-cli-pager --query UserId --output text)
 
 container_name=$(aws ecs describe-task-definition --task-definition "${task_definition_family}" --query "taskDefinition.containerDefinitions[?name == '${service_name}'].name" --output text)

--- a/bin/run-command
+++ b/bin/run-command
@@ -90,7 +90,7 @@ service_task_definition_arn=$(aws ecs describe-services --no-cli-pager --cluster
 task_definition_family=$(aws ecs describe-task-definition --no-cli-pager --task-definition "${service_task_definition_arn}" --query "taskDefinition.family" --output text)
 
 network_config=$(aws ecs describe-services --no-cli-pager --cluster "${cluster_name}" --services "${service_name}" --query "services[0].networkConfiguration")
-current_region=$(./aws configure get region)
+current_region=$(aws configure get region)
 aws_user_id=$(aws sts get-caller-identity --no-cli-pager --query UserId --output text)
 
 container_name=$(aws ecs describe-task-definition --task-definition "${task_definition_family}" --query "taskDefinition.containerDefinitions[?name == '${service_name}'].name" --output text)

--- a/bin/set-up-current-account
+++ b/bin/set-up-current-account
@@ -25,7 +25,7 @@ set -euo pipefail
 account_name="$1"
 
 account_id=$(./bin/current-account-id)
-region=$(./bin/current-region)
+region=$(aws configure get region)
 
 # Get project name
 terraform -chdir="infra/project-config" apply -auto-approve > /dev/null


### PR DESCRIPTION
## Ticket

Resolves #{TICKET NUMBER OR URL}

## Changes

- Replace calls to current-region with aws configure get region
- Remove current-region script

## Context for reviewers

Recently there's been sporadic errors where the current-region script would return `:` instead of the region. This approach should be more robust and also remove the need for the extra current-region script.

## Testing

CI should cover at least a few of the changes (e.g. in publish-release)