### PR TITLE
[WIP] Update CI to use docker build caching

### DIFF
--- a/.github/actions/build-release-image/action.yml
+++ b/.github/actions/build-release-image/action.yml
@@ -1,0 +1,45 @@
+name: Build release candidate
+description: Builds a docker image and leverages the build cache to re-use results from previous builds.
+
+inputs:
+  app_name:
+    required: true
+    type: string
+    description: 'Name of application folder'
+  commit_hash:
+    required: false
+    type: string
+    description: 'The commit hash'
+    default: ${{ github.sha }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Restore from Cache
+      id: cache-buildx
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ inputs.app_name }}-buildx-${{ inputs.commit_hash }}
+        restore-keys: |
+          ${{ inputs.app_name }}-buildx-
+
+    - name: Build and tag Docker image for scanning
+      if: steps.cache-buildx.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        make APP_NAME=${{ inputs.app_name }} release-build \
+        OPTIONAL_BUILD_FLAGS=" \
+        --cache-from=type=local,src=/tmp/.buildx-cache \
+        --cache-to=type=local,dest=/tmp/.buildx-cache-new"
+
+    - name: Replace the cache
+      if: steps.cache-buildx.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -79,38 +79,12 @@ jobs:
           echo "Is image published: $is_image_published"
           echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
 
-#      - name: Build release
-#        if: steps.check-image-published.outputs.is_image_published == 'false'
-#        run: make APP_NAME=${{ inputs.app_name }} release-build
-
-#     START: use docker layer cache 
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Restore from cache
-        id: cache-buildx
-        uses: actions/cache@v4
+      - uses: ./.github/actions/build-release-image
+        if: steps.check-image-published.outputs.is_image_published == 'false'
+        id: build-release-image
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ inputs.app_name }}-buildx-${{ needs.get-commit-hash.outputs.commit_hash }}
-          restore-keys: |
-            ${{ inputs.app_name }}-buildx-
-
-      - name: Build and tag Docker image for scanning
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build \
-          OPTIONAL_BUILD_FLAGS=" \
-          --cache-from=type=local,src=/tmp/.buildx-cache \
-          --cache-to=type=local,dest=/tmp/.buildx-cache-new"
-
-      - name: Replace the build cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-#     END: use docker layer cache 
+          app_name: ${{ inputs.app_name }}
+          commit_hash: ${{ needs.get-commit-hash.outputs.commit_hash }}
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -79,9 +79,38 @@ jobs:
           echo "Is image published: $is_image_published"
           echo "is_image_published=$is_image_published" >> "$GITHUB_OUTPUT"
 
-      - name: Build release
-        if: steps.check-image-published.outputs.is_image_published == 'false'
-        run: make APP_NAME=${{ inputs.app_name }} release-build
+#      - name: Build release
+#        if: steps.check-image-published.outputs.is_image_published == 'false'
+#        run: make APP_NAME=${{ inputs.app_name }} release-build
+
+#     START: use docker layer cache 
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore from cache
+        id: cache-buildx
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ inputs.app_name }}-buildx-${{ needs.get-commit-hash.outputs.commit_hash }}
+          restore-keys: |
+            ${{ inputs.app_name }}-buildx-
+
+      - name: Build and tag Docker image for scanning
+        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        run: |
+          make APP_NAME=${{ inputs.app_name }} release-build \
+          OPTIONAL_BUILD_FLAGS=" \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache-new"
+
+      - name: Replace the build cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+#     END: use docker layer cache 
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -41,8 +41,25 @@ jobs:
         if: always() # Runs even if there is a failure
         run: cat hadolint-results.txt >> "$GITHUB_STEP_SUMMARY"
 
+  get-image-ref:
+    name: Get image ref
+    runs-on: ubuntu-latest
+
+    outputs:
+      image: ${{ steps.get-image-ref.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: get-image-ref
+        run: |
+          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
+          IMAGE_TAG=$(make release-image-tag)
+          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
   trivy-scan:
     runs-on: ubuntu-latest
+    needs: get-image-ref
 
     steps:
       - uses: actions/checkout@v4
@@ -59,19 +76,16 @@ jobs:
         with:
           files: ${{ inputs.app_name }}/trivy-secret.yaml trivy-secret.yaml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/build-release-image
+        id: build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
-          image-ref: ${{ steps.build-image.outputs.image }}
+          image-ref: ${{ needs.get-image-ref.outputs.image }}
           format: table
           exit-code: 1
           ignore-unfixed: true
@@ -88,6 +102,7 @@ jobs:
 
   anchore-scan:
     runs-on: ubuntu-latest
+    needs: get-image-ref
 
     steps:
       - uses: actions/checkout@v4
@@ -99,18 +114,15 @@ jobs:
             ${{ inputs.app_name }}/.grype.yml
             .grype.yml
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/build-release-image
+        id: build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
 
       - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v6
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.get-image-ref.outputs.image }}
           output-format: table
         env:
           GRYPE_CONFIG: ${{ steps.grype-config.outputs.found_file }}
@@ -121,6 +133,7 @@ jobs:
 
   dockle-scan:
     runs-on: ubuntu-latest
+    needs: get-image-ref
 
     steps:
       - uses: actions/checkout@v4
@@ -132,13 +145,10 @@ jobs:
             ${{ inputs.app_name }}/.dockleconfig
             .dockleconfig
 
-      - name: Build and tag Docker image for scanning
-        id: build-image
-        run: |
-          make APP_NAME=${{ inputs.app_name }} release-build
-          IMAGE_NAME=$(make APP_NAME=${{ inputs.app_name }} release-image-name)
-          IMAGE_TAG=$(make release-image-tag)
-          echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/build-release-image
+        id: build-release-image
+        with:
+          app_name: ${{ inputs.app_name }}
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable, this will save the variable in this file to env for Dockle
@@ -151,7 +161,7 @@ jobs:
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.3.1
         with:
-          image: ${{ steps.build-image.outputs.image }}
+          image: ${{ needs.get-image-ref.outputs.image }}
           exit-code: "1"
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ endif
 release-build: ## Build release for $APP_NAME and tag it with current git hash
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	cd $(APP_NAME) && $(MAKE) release-build \
-		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG)"
+		OPTS="--tag $(IMAGE_NAME):latest --tag $(IMAGE_NAME):$(IMAGE_TAG) --load -t $(IMAGE_NAME):$(IMAGE_TAG) $(OPTIONAL_BUILD_FLAGS)"
 
 release-publish: ## Publish release to $APP_NAME's build repository
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra/issues/936

## Changes

Introduces docker build caching to the CI process for building a component's docker image. This is implemented as a new GitHub composite action that surrounds the `make APP_NAME=${{ inputs.app_name }} release-build` with steps to allow for cadhing.

Updates workflows `build-and-publish` and `vulnerability-scans` to use the new composite action.

## Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.

## Testing

> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
