### PR TITLE
Set all installed Apps DB_AUTH_METHOD environment variable to "aws_iam"

### DIFF
--- a/infra/app-catala/app-config/env-config/environment_variables.tf
+++ b/infra/app-catala/app-config/env-config/environment_variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "aws_iam"
   }
 
   # Configuration for secrets

--- a/infra/app-flask/app-config/env-config/environment_variables.tf
+++ b/infra/app-flask/app-config/env-config/environment_variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "aws_iam"
   }
 
   # Configuration for secrets

--- a/infra/app-nextjs/app-config/env-config/environment_variables.tf
+++ b/infra/app-nextjs/app-config/env-config/environment_variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "aws_iam"
   }
 
   # Configuration for secrets

--- a/infra/app-rails/app-config/env-config/environment_variables.tf
+++ b/infra/app-rails/app-config/env-config/environment_variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "aws_iam"
   }
 
   # Configuration for secrets

--- a/infra/app/app-config/env-config/environment_variables.tf
+++ b/infra/app/app-config/env-config/environment_variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "aws_iam"
   }
 
   # Configuration for secrets


### PR DESCRIPTION
## Ticket

Resolves application deployment issues where applications are not connecting to AWS Database

## Changes

Sets application DB_AUTH_METHOD = "aws_iam"

## Context for reviewers
This fixes current deployment issue

A recent update to the Rails application template enables database connectivity based on the DB_AUTH_METHOD environment variable. Supported values include:

aws_iam → connects to an AWS database
azure_entra → connects to an Azure database
(unset) → defaults to a local database connection 

This change sets DB_AUTH_METHOD = "aws_iam" across all applications. It is currently unset which is causing Applications to fail during deployment while trying to execute db migration and not able to connect to db.

## Testing

https://github.com/navapbc/platform-test/pull/279#issue-4354331836

<!-- app-catala - begin PR environment info -->
## Preview environment for app-catala
- Service endpoint: http://p-286-app-catala-dev-1322165125.us-east-1.elb.amazonaws.com
- Deployed commit: 36411dc18b258c45af61b08602beb901cfb3f2f6
<!-- app-catala - end PR environment info -->

<!-- app-nextjs - begin PR environment info -->
## Preview environment for app-nextjs
♻️ Environment destroyed ♻️
<!-- app-nextjs - end PR environment info -->

<!-- app-flask - begin PR environment info -->
## Preview environment for app-flask
♻️ Environment destroyed ♻️
<!-- app-flask - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
♻️ Environment destroyed ♻️
<!-- app-rails - end PR environment info -->