### PR TITLE
[navapbc/template-infra] Test Template PR: doshitan/vuln-scanning-tweaks

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,5 @@
+# https://github.com/goodwithtech/dockle/issues/282
+DKL-DI-0005
+# Docker Content Trust is retired
+# https://github.com/goodwithtech/dockle/issues/289
+CIS-DI-0005

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -3,4 +3,6 @@
 # For more information on any settings you can specify, see the actions' documentation here
 # https://github.com/hadolint/hadolint#configure
 failure-threshold: warning
-ignored: []
+ignored:
+  # not necessarily a bad idea, but can be brittle and a maintenance burden
+  - DL3008

--- a/.template-infra/app-app-catala.yml
+++ b/.template-infra/app-app-catala.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3400

--- a/.template-infra/app-app-docuai.yml
+++ b/.template-infra/app-app-docuai.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3500

--- a/.template-infra/app-app-flask.yml
+++ b/.template-infra/app-app-flask.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3200

--- a/.template-infra/app-app-nextjs.yml
+++ b/.template-infra/app-app-nextjs.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3300

--- a/.template-infra/app-app-rails.yml
+++ b/.template-infra/app-app-rails.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3100

--- a/.template-infra/app-app.yml
+++ b/.template-infra/app-app.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 app_has_dev_env_setup: true
 app_local_port: 3000

--- a/.template-infra/base.yml
+++ b/.template-infra/base.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.18.0-38-g1e671f0
+_commit: v0.18.0-40-g327b158
 _src_path: https://github.com/navapbc/template-infra
 base_code_repository_url: git@github.com:navapbc/platform-test.git
 base_default_region: us-east-1


### PR DESCRIPTION
Basically changes from: https://github.com/navapbc/template-infra/tree/doshitan/vuln-scanning-tweaks

But the CI job had trouble automatically making the changes to open the PR, so applied manually and pushed.

<!-- app - begin PR environment info -->
## Preview environment for app
♻️ Environment destroyed ♻️
<!-- app - end PR environment info -->

<!-- app-flask - begin PR environment info -->
## Preview environment for app-flask
♻️ Environment destroyed ♻️
<!-- app-flask - end PR environment info -->

<!-- app-nextjs - begin PR environment info -->
## Preview environment for app-nextjs
♻️ Environment destroyed ♻️
<!-- app-nextjs - end PR environment info -->

<!-- app-docuai - begin PR environment info -->
## Preview environment for app-docuai
♻️ Environment destroyed ♻️
<!-- app-docuai - end PR environment info -->

<!-- app-catala - begin PR environment info -->
## Preview environment for app-catala
♻️ Environment destroyed ♻️
<!-- app-catala - end PR environment info -->

<!-- app-rails - begin PR environment info -->
## Preview environment for app-rails
♻️ Environment destroyed ♻️
<!-- app-rails - end PR environment info -->